### PR TITLE
feat: add student message center with offline support

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,14 +8,22 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.1.2",
+        "@tanstack/react-query": "^5.62.9",
+        "@tanstack/react-query-devtools": "^5.62.9",
         "canvas-confetti": "^1.9.3",
+        "class-variance-authority": "^0.7.0",
+        "date-fns": "^3.6.0",
         "framer-motion": "^12.23.12",
+        "lucide-react": "^0.474.0",
         "next": "15.5.3",
         "next-intl": "^4.3.8",
         "react": "19.1.0",
         "react-circular-progressbar": "^2.2.0",
         "react-confetti": "^6.4.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "react-icons": "^5.3.0",
+        "tailwind-merge": "^2.5.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1015,6 +1023,39 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1320,6 +1361,59 @@
         "tailwindcss": "4.1.13"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.89.0.tgz",
+      "integrity": "sha512-joFV1MuPhSLsKfTzwjmPDrp8ENfZ9N23ymFu07nLfn3JCkSHy0CFgsyhHTJOmWaumC/WiNIKM0EJyduCF/Ih/Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.87.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.87.3.tgz",
+      "integrity": "sha512-LkzxzSr2HS1ALHTgDmJH5eGAVsSQiuwz//VhFW5OqNk0OQ+Fsqba0Tsf+NzWRtXYvpgUqwQr4b2zdFZwxHcGvg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.89.0.tgz",
+      "integrity": "sha512-SXbtWSTSRXyBOe80mszPxpEbaN4XPRUp/i0EfQK1uyj3KCk/c8FuPJNIRwzOVe/OU3rzxrYtiNabsAmk1l714A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.89.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.89.0.tgz",
+      "integrity": "sha512-Syc4UjZeIJCkXCRGyQcWwlnv89JNb98MMg/DAkFCV3rwOcknj98+nG3Nm6xLXM6ne9sK6RZeDJMPLKZUh6NUGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.87.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.89.0",
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1373,7 +1467,7 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2380,11 +2474,32 @@
         "node": ">=18"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -2457,7 +2572,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2519,6 +2634,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -4609,6 +4734,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.474.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.474.0.tgz",
+      "integrity": "sha512-CmghgHkh0OJNmxGKWc0qfPJCYHASPMVSyGY8fj3xgk4v84ItqDg64JNKFZn5hC6E0vHi6gxnbCgwhyVB09wQtA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -5281,6 +5415,15 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -5896,6 +6039,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,14 +10,22 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.2",
+    "@tanstack/react-query": "^5.62.9",
+    "@tanstack/react-query-devtools": "^5.62.9",
+    "class-variance-authority": "^0.7.0",
+    "date-fns": "^3.6.0",
     "canvas-confetti": "^1.9.3",
     "framer-motion": "^12.23.12",
+    "lucide-react": "^0.474.0",
     "next": "15.5.3",
     "next-intl": "^4.3.8",
     "react": "19.1.0",
     "react-circular-progressbar": "^2.2.0",
     "react-confetti": "^6.4.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-icons": "^5.3.0",
+    "tailwind-merge": "^2.5.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ import OfflineIndicator, { OfflineBadge } from '@/components/OfflineIndicator';
 import { offlineApi, isDataStale } from '@/lib/offlineApi';
 import { useTranslations } from 'next-intl';
 import MemorizationSection from '@/components/MemorizationSection';
+import MessageSection from '@/components/student/MessageSection';
 import MemorizationOversight from '@/components/MemorizationOversight';
 
 interface DashboardStats {
@@ -549,14 +550,25 @@ export default function DashboardPage() {
               </motion.div>
             </div>
 
-            {/* Memorization Section */}
-            <motion.div 
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.6 }}
-            >
-              <MemorizationSection />
-            </motion.div>
+            {/* Message Center & Memorization */}
+            <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.5 }}
+                className="h-full"
+              >
+                <MessageSection />
+              </motion.div>
+
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.65 }}
+              >
+                <MemorizationSection />
+              </motion.div>
+            </div>
           </div>
         )}
 

--- a/apps/web/src/components/student/MessageSection.tsx
+++ b/apps/web/src/components/student/MessageSection.tsx
@@ -1,0 +1,606 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  QueryClient,
+  QueryClientProvider,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { AnimatePresence, motion } from 'framer-motion';
+import { formatDistanceToNow } from 'date-fns';
+import { Mail, MailOpen, RefreshCw, Sparkles, WifiOff, CheckCircle2 } from 'lucide-react';
+
+import { api } from '@/lib/api';
+import { CACHE_KEYS, indexedDBService } from '@/lib/indexedDB';
+import { cn } from '@/lib/utils';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000/api';
+
+type Nullable<T> = T | null | undefined;
+
+interface MessageSender {
+  id: Nullable<number>;
+  name: string;
+  avatar_url?: Nullable<string>;
+}
+
+interface MessageAssignment {
+  id: number;
+  title: string;
+  due_date?: Nullable<string>;
+}
+
+interface MessageSchedule {
+  id: number;
+  title: string;
+  scheduled_for?: Nullable<string>;
+}
+
+export interface StudentMessage {
+  id: number;
+  title: string;
+  subtitle?: Nullable<string>;
+  body: string;
+  sender: MessageSender;
+  created_at?: Nullable<string>;
+  read_at?: Nullable<string>;
+  assignment?: Nullable<MessageAssignment>;
+  schedule?: Nullable<MessageSchedule>;
+  metadata?: Record<string, any> | null;
+}
+
+const MESSAGE_CACHE_TTL_MINUTES = 120;
+const QUERY_KEY = ['student-messages'];
+
+function normalizeMessage(raw: any): StudentMessage {
+  const sender: MessageSender = {
+    id: raw?.sender?.id ?? raw?.sender_id ?? null,
+    name: raw?.sender?.name ?? raw?.sender_name ?? 'Teacher',
+    avatar_url: raw?.sender?.avatar_url ?? raw?.sender_avatar ?? undefined,
+  };
+
+  const assignment: MessageAssignment | null = raw?.assignment || raw?.assignment_id
+    ? {
+        id: Number(raw?.assignment?.id ?? raw?.assignment_id ?? 0),
+        title: raw?.assignment?.title ?? raw?.assignment_title ?? 'Assignment',
+        due_date: raw?.assignment?.due_date ?? raw?.assignment_due_date ?? null,
+      }
+    : null;
+
+  const schedule: MessageSchedule | null = raw?.schedule || raw?.schedule_id
+    ? {
+        id: Number(raw?.schedule?.id ?? raw?.schedule_id ?? 0),
+        title: raw?.schedule?.title ?? raw?.schedule_title ?? 'Schedule',
+        scheduled_for: raw?.schedule?.scheduled_for ?? raw?.schedule_date ?? null,
+      }
+    : null;
+
+  return {
+    id: Number(raw?.id ?? raw?.message_id ?? Date.now()),
+    title: raw?.title ?? 'New Message',
+    subtitle: raw?.subtitle ?? raw?.subject ?? '',
+    body: raw?.body ?? raw?.content ?? '',
+    sender,
+    created_at: raw?.created_at ?? raw?.sent_at ?? new Date().toISOString(),
+    read_at:
+      raw?.read_at ??
+      (raw?.is_read
+        ? raw?.updated_at ?? new Date().toISOString()
+        : null),
+    assignment,
+    schedule,
+    metadata: raw?.metadata ?? null,
+  };
+}
+
+async function fetchStudentMessages(): Promise<StudentMessage[]> {
+  try {
+    const response = await api.get<StudentMessage[]>('/student/messages');
+    const payload = (response?.data as any) ?? response;
+
+    const messagesArray: any[] = Array.isArray(payload)
+      ? payload
+      : Array.isArray(payload?.data)
+      ? payload.data
+      : [];
+
+    const normalized = messagesArray.map(normalizeMessage);
+    await indexedDBService.setCache(
+      CACHE_KEYS.STUDENT_MESSAGES,
+      normalized,
+      MESSAGE_CACHE_TTL_MINUTES,
+    );
+    return normalized;
+  } catch (error) {
+    const cached = await indexedDBService.getCache(CACHE_KEYS.STUDENT_MESSAGES);
+    if (cached) {
+      return (cached as any[]).map(normalizeMessage);
+    }
+    throw error;
+  }
+}
+
+async function markStudentMessageRead(
+  messageId: number,
+): Promise<{ queued: boolean }> {
+  const token =
+    typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  try {
+    const response = await fetch(
+      `${API_BASE}/student/messages/${messageId}/read`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({}),
+      },
+    );
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || 'Failed to mark message as read');
+    }
+
+    return { queued: false };
+  } catch (error) {
+    if (error instanceof TypeError) {
+      await indexedDBService.addToOfflineQueue(
+        `${API_BASE}/student/messages/${messageId}/read`,
+        'POST',
+        JSON.stringify({}),
+        headers,
+      );
+      return { queued: true };
+    }
+    throw error;
+  }
+}
+
+function useMessageCacheWarmup() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    let isMounted = true;
+
+    (async () => {
+      try {
+        const cached = await indexedDBService.getCache(
+          CACHE_KEYS.STUDENT_MESSAGES,
+        );
+        if (cached && isMounted) {
+          queryClient.setQueryData<StudentMessage[]>(
+            QUERY_KEY,
+            (cached as any[]).map(normalizeMessage),
+          );
+        }
+      } catch (error) {
+        console.error('Failed to load cached messages:', error);
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [queryClient]);
+}
+
+function MessageSectionContent() {
+  const queryClient = useQueryClient();
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [isOffline, setIsOffline] = useState<boolean>(
+    typeof navigator !== 'undefined' ? !navigator.onLine : false,
+  );
+
+  useMessageCacheWarmup();
+
+  const {
+    data: messages = [],
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+  } = useQuery<StudentMessage[]>({
+    queryKey: QUERY_KEY,
+    queryFn: fetchStudentMessages,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const sortedMessages = useMemo(() => {
+    return [...messages].sort((a, b) => {
+      const aDate = a.created_at ? new Date(a.created_at).getTime() : 0;
+      const bDate = b.created_at ? new Date(b.created_at).getTime() : 0;
+      return bDate - aDate;
+    });
+  }, [messages]);
+
+  useEffect(() => {
+    if (!sortedMessages.length) {
+      setSelectedId(null);
+      return;
+    }
+
+    const hasSelected = sortedMessages.some((msg) => msg.id === selectedId);
+    if (!hasSelected) {
+      setSelectedId(sortedMessages[0].id);
+    }
+  }, [sortedMessages, selectedId]);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      setIsOffline(false);
+      setStatusMessage('Alhamdulillah! You are back online. Refreshing messages.');
+      refetch();
+    };
+
+    const handleOffline = () => {
+      setIsOffline(true);
+      setStatusMessage('You are offline. Showing your saved messages.');
+    };
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, [refetch]);
+
+  useEffect(() => {
+    if (!statusMessage) return;
+    const timeout = window.setTimeout(() => setStatusMessage(null), 4000);
+    return () => window.clearTimeout(timeout);
+  }, [statusMessage]);
+
+  const markAsRead = useMutation({
+    mutationFn: markStudentMessageRead,
+    onSuccess: async (result, messageId) => {
+      queryClient.setQueryData<StudentMessage[]>(QUERY_KEY, (prev) => {
+        if (!prev) return prev;
+        const updated = prev.map((message) =>
+          message.id === messageId
+            ? {
+                ...message,
+                read_at: new Date().toISOString(),
+              }
+            : message,
+        );
+        void indexedDBService.setCache(
+          CACHE_KEYS.STUDENT_MESSAGES,
+          updated,
+          MESSAGE_CACHE_TTL_MINUTES,
+        );
+        return updated;
+      });
+
+      setStatusMessage(
+        result.queued
+          ? 'Message acknowledged offline. We will sync your read receipt soon.'
+          : 'MashaAllah! Message marked as read.',
+      );
+    },
+    onError: (mutationError: unknown) => {
+      const description =
+        mutationError instanceof Error
+          ? mutationError.message
+          : 'Unable to mark message as read.';
+      setStatusMessage(description);
+    },
+  });
+
+  const unreadCount = useMemo(
+    () => messages.filter((msg) => !msg.read_at).length,
+    [messages],
+  );
+
+  const selectedMessage = sortedMessages.find((msg) => msg.id === selectedId) ?? null;
+
+  const renderBody = (body: string) => {
+    const paragraphs = body.split('\n').filter(Boolean);
+    return paragraphs.length ? (
+      <div className="space-y-3 text-sm leading-relaxed text-gray-700">
+        {paragraphs.map((paragraph, index) => (
+          <p key={index}>{paragraph}</p>
+        ))}
+      </div>
+    ) : (
+      <p className="text-sm text-gray-500">No additional details.</p>
+    );
+  };
+
+  return (
+    <Card className="h-full bg-gradient-to-br from-[#FAF7F2] via-white to-white/90 border border-gold-200 shadow-xl">
+      <CardHeader className="pb-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-2xl font-semibold text-maroon-800">
+              <Sparkles className="h-6 w-6 text-gold-500" aria-hidden="true" />
+              Message Center
+            </CardTitle>
+            <CardDescription className="text-sm text-maroon-600">
+              Guidance and reminders from your teachers, beautifully curated for your Qur'anic journey.
+            </CardDescription>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge
+              variant="secondary"
+              className={cn(
+                'rounded-full bg-gold-100 px-3 py-1 text-xs font-semibold text-gold-700 shadow-sm',
+                unreadCount === 0 && 'bg-emerald-100 text-emerald-700',
+              )}
+            >
+              {unreadCount} unread
+            </Badge>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => refetch()}
+              className="border-gold-300 text-maroon-700 hover:bg-gold-50"
+              aria-label="Refresh messages"
+              disabled={isFetching}
+            >
+              <RefreshCw className={cn('mr-2 h-4 w-4', isFetching && 'animate-spin')} />
+              Refresh
+            </Button>
+          </div>
+        </div>
+
+        {isOffline && (
+          <motion.div
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mt-3 flex items-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+          >
+            <WifiOff className="h-4 w-4" aria-hidden="true" />
+            Offline mode enabled. We will sync once you're connected again.
+          </motion.div>
+        )}
+
+        <AnimatePresence>
+          {statusMessage && (
+            <motion.div
+              key={statusMessage}
+              initial={{ opacity: 0, y: -6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -6 }}
+              className="mt-3 flex items-center gap-2 rounded-xl border border-maroon-200 bg-maroon-50 px-3 py-2 text-sm text-maroon-700 shadow-sm"
+            >
+              <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+              {statusMessage}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </CardHeader>
+
+      <CardContent className="pt-0">
+        {isLoading ? (
+          <div className="grid gap-6 md:grid-cols-[minmax(0,260px)_1fr]">
+            <div className="space-y-3">
+              {[0, 1, 2].map((item) => (
+                <div
+                  key={item}
+                  className="h-20 animate-pulse rounded-2xl bg-gradient-to-r from-maroon-100/40 via-white to-gold-100/40"
+                />
+              ))}
+            </div>
+            <div className="h-64 animate-pulse rounded-3xl bg-gradient-to-br from-white via-maroon-50/60 to-gold-50" />
+          </div>
+        ) : error ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-700">
+            Unable to load your messages at this time. Please try refreshing or check your connection.
+          </div>
+        ) : sortedMessages.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-gold-300 bg-white/70 p-10 text-center text-maroon-700">
+            <MailOpen className="h-10 w-10 text-gold-500" aria-hidden="true" />
+            <div>
+              <h3 className="text-lg font-semibold">No messages yet</h3>
+              <p className="text-sm text-maroon-500">
+                Your teachers will send guidance and reflections here. Keep reciting and stay tuned!
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-[minmax(0,280px)_1fr]">
+            <div className="max-h-[26rem] space-y-3 overflow-y-auto pr-1">
+              <AnimatePresence>
+                {sortedMessages.map((message) => {
+                  const isSelected = message.id === selectedId;
+                  const isUnread = !message.read_at;
+                  return (
+                    <motion.button
+                      key={message.id}
+                      layout
+                      initial={{ opacity: 0, y: 10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, x: -10 }}
+                      whileHover={{ scale: 1.01 }}
+                      onClick={() => setSelectedId(message.id)}
+                      className={cn(
+                        'w-full rounded-2xl border p-4 text-left transition-all focus:outline-none focus:ring-2 focus:ring-maroon-400',
+                        isSelected
+                          ? 'border-transparent bg-gradient-to-r from-maroon-600 via-maroon-500 to-gold-500 text-white shadow-lg'
+                          : isUnread
+                          ? 'border-gold-200 bg-gradient-to-r from-gold-50 via-white to-gold-100 text-maroon-800 shadow-sm'
+                          : 'border-maroon-100 bg-white/80 text-maroon-700 hover:border-maroon-300',
+                      )}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="space-y-1">
+                          <p className="text-sm font-semibold">
+                            {message.title}
+                          </p>
+                          {message.subtitle && (
+                            <p
+                              className={cn(
+                                'text-xs',
+                                isSelected ? 'text-gold-100/90' : 'text-maroon-500',
+                              )}
+                            >
+                              {message.subtitle}
+                            </p>
+                          )}
+                        </div>
+                        {isUnread ? (
+                          <Badge className="flex items-center gap-1 rounded-full bg-white/20 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white">
+                            <Mail className="h-3 w-3" aria-hidden="true" />
+                            New
+                          </Badge>
+                        ) : (
+                          <Badge className="rounded-full bg-white/20 px-2 py-0.5 text-[11px] text-white/80">
+                            Read
+                          </Badge>
+                        )}
+                      </div>
+                      <p
+                        className={cn(
+                          'mt-3 line-clamp-2 text-xs',
+                          isSelected ? 'text-white/90' : 'text-maroon-600/80',
+                        )}
+                      >
+                        {message.body}
+                      </p>
+                      <p
+                        className={cn(
+                          'mt-4 text-[11px] font-medium',
+                          isSelected ? 'text-white/70' : 'text-maroon-400',
+                        )}
+                      >
+                        {formatDistanceToNow(
+                          message.created_at ? new Date(message.created_at) : new Date(),
+                          { addSuffix: true },
+                        )}
+                      </p>
+                    </motion.button>
+                  );
+                })}
+              </AnimatePresence>
+            </div>
+
+            <div className="rounded-3xl border border-maroon-100 bg-white/90 p-6 shadow-inner">
+              {selectedMessage && (
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge className="rounded-full bg-maroon-600/90 px-3 py-1 text-xs font-semibold text-white shadow">
+                      From {selectedMessage.sender.name}
+                    </Badge>
+                    {selectedMessage.assignment && (
+                      <Badge className="rounded-full bg-gold-500/90 px-3 py-1 text-xs font-semibold text-white shadow">
+                        Assignment: {selectedMessage.assignment.title}
+                      </Badge>
+                    )}
+                    {selectedMessage.schedule && (
+                      <Badge className="rounded-full bg-emerald-500/90 px-3 py-1 text-xs font-semibold text-white shadow">
+                        Schedule: {selectedMessage.schedule.title}
+                      </Badge>
+                    )}
+                  </div>
+
+                  <div className="space-y-3">
+                    <h3 className="text-xl font-semibold text-maroon-800">
+                      {selectedMessage.title}
+                    </h3>
+                    {selectedMessage.subtitle && (
+                      <p className="text-sm font-medium text-gold-700">
+                        {selectedMessage.subtitle}
+                      </p>
+                    )}
+                    <div className="rounded-2xl border border-gold-200/80 bg-white/70 p-5 shadow-sm">
+                      {renderBody(selectedMessage.body)}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-3 text-xs text-maroon-500">
+                    <span>
+                      Sent{' '}
+                      {formatDistanceToNow(
+                        selectedMessage.created_at
+                          ? new Date(selectedMessage.created_at)
+                          : new Date(),
+                        { addSuffix: true },
+                      )}
+                    </span>
+                    {selectedMessage.assignment?.due_date && (
+                      <span>
+                        Due by {new Date(selectedMessage.assignment.due_date).toLocaleDateString()}
+                      </span>
+                    )}
+                    {selectedMessage.schedule?.scheduled_for && (
+                      <span>
+                        Scheduled for{' '}
+                        {new Date(selectedMessage.schedule.scheduled_for).toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="border-maroon-300 bg-maroon-600/10 text-maroon-700 hover:bg-maroon-600/20"
+                      onClick={() => markAsRead.mutate(selectedMessage.id)}
+                      disabled={Boolean(selectedMessage.read_at) || markAsRead.isPending}
+                    >
+                      <MailOpen className="mr-2 h-4 w-4" aria-hidden="true" />
+                      {selectedMessage.read_at ? 'Already read' : 'Mark as read'}
+                    </Button>
+
+                    <div className="text-xs text-maroon-500">
+                      {selectedMessage.read_at
+                        ? `Read ${formatDistanceToNow(new Date(selectedMessage.read_at), {
+                            addSuffix: true,
+                          })}`
+                        : 'Gain barakah by acknowledging your teacher\'s reminder.'}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function MessageSection() {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: 1,
+            refetchOnReconnect: true,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MessageSectionContent />
+    </QueryClientProvider>
+  );
+}

--- a/apps/web/src/lib/indexedDB.ts
+++ b/apps/web/src/lib/indexedDB.ts
@@ -491,6 +491,7 @@ export const CACHE_KEYS = {
   AYAH_OF_DAY: 'ayah-of-day',
   WEEKLY_PROGRESS: 'weekly-progress',
   LEADERBOARD: 'leaderboard',
+  STUDENT_MESSAGES: 'student-messages',
   USER_PROFILE: 'user-profile',
   MEMORIZATION_PLANS: 'memorization-plans',
   DUE_REVIEWS: 'due-reviews',


### PR DESCRIPTION
## Summary
- add a dedicated student MessageSection component with offline caching, animations, and read receipt queueing
- surface the message center on the student dashboard alongside memorization tools and expand IndexedDB cache keys
- install missing UI/support libraries (react-query, date-fns, lucide-react, tailwind-merge, etc.) required by existing and new components

## Testing
- npm run lint *(fails: numerous pre-existing lint errors throughout the project unrelated to the new component)*

------
https://chatgpt.com/codex/tasks/task_e_68cb42744acc8327840b2572f163cb4e