### PR TITLE
Align teacher dashboard frontend with API and add grading endpoint

### DIFF
--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -444,6 +444,7 @@ Route::middleware('auth:sanctum')->group(function () {
          Route::get('/student-progress', [MainTeacherController::class, 'getStudentProgress']);
          Route::get('/game-analytics', [MainTeacherController::class, 'getGameAnalytics']);
          Route::post('/analytics/update', [MainTeacherController::class, 'updateAnalytics']);
+        Route::post('/submissions/{submission}/grade', [MainTeacherController::class, 'gradeSubmission']);
      });
 });
 

--- a/apps/web/src/components/teacher/AnalyticsSection.tsx
+++ b/apps/web/src/components/teacher/AnalyticsSection.tsx
@@ -1,141 +1,107 @@
-/* AlFawz Qur'an Institute — generated with TRAE */
-/* Author: Auto-scaffold (review required) */
-
 'use client';
 
 import React from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
-import { useQuery } from '@tanstack/react-query';
-import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
-import 'react-circular-progressbar/dist/styles.css';
+import { api } from '@/lib/api';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { 
-  Users, 
-  TrendingUp, 
-  Award, 
-  Clock,
-  BookOpen,
+import {
+  Users,
+  TrendingUp,
   Target,
   Zap,
-  Star
+  Award,
+  BookOpen,
+  ClipboardList,
+  Clock,
 } from 'lucide-react';
+import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
+import 'react-circular-progressbar/dist/styles.css';
 
-// Types for analytics data
-interface AnalyticsData {
+interface RawAnalytics {
+  total_students?: number;
+  completion_rate?: number;
+  hotspot_interactions?: number;
+  game_sessions?: number;
+  high_scores?: number;
+  average_score?: number;
+  active_assignments?: number;
+  pending_submissions?: number;
+  last_updated?: string | null;
+}
+
+interface AnalyticsSummary {
   totalStudents: number;
   completionRate: number;
   hotspotInteractions: number;
   gameSessions: number;
   highScores: number;
   averageScore: number;
-  weeklyProgress: number;
-  monthlyGrowth: number;
+  activeAssignments: number;
+  pendingSubmissions: number;
+  lastUpdated?: string | null;
 }
 
-/**
- * Fetch teacher analytics data from API
- * @returns Promise with analytics data
- */
-const fetchAnalytics = async (): Promise<AnalyticsData> => {
-  const response = await fetch('/api/teacher/dashboard', {
-    headers: {
-      'Authorization': `Bearer ${localStorage.getItem('auth_token')}`,
-      'Content-Type': 'application/json',
-    },
-  });
-  
-  if (!response.ok) {
-    throw new Error('Failed to fetch analytics data');
-  }
-  
-  const data = await response.json();
-  return data.analytics;
+const fetchAnalytics = async (): Promise<AnalyticsSummary> => {
+  const response = await api.get('/teacher/dashboard');
+  const payload = ((response as any)?.analytics ?? (response as any)?.data?.analytics ?? {}) as RawAnalytics;
+
+  return {
+    totalStudents: Number(payload.total_students ?? 0),
+    completionRate: Number(payload.completion_rate ?? 0),
+    hotspotInteractions: Number(payload.hotspot_interactions ?? 0),
+    gameSessions: Number(payload.game_sessions ?? 0),
+    highScores: Number(payload.high_scores ?? 0),
+    averageScore: Number(payload.average_score ?? 0),
+    activeAssignments: Number(payload.active_assignments ?? 0),
+    pendingSubmissions: Number(payload.pending_submissions ?? 0),
+    lastUpdated: payload.last_updated ?? null,
+  };
 };
 
-/**
- * Individual metric card component with circular progress
- * @param title - Metric title
- * @param value - Current value
- * @param percentage - Progress percentage (0-100)
- * @param icon - Lucide icon component
- * @param color - Theme color for progress bar
- * @param trend - Optional trend indicator
- */
 interface MetricCardProps {
   title: string;
   value: number | string;
   percentage: number;
   icon: React.ElementType;
   color: string;
-  trend?: {
-    value: number;
-    isPositive: boolean;
-  };
+  helper?: string;
 }
 
-function MetricCard({ title, value, percentage, icon: Icon, color, trend }: MetricCardProps) {
+function MetricCard({ title, value, percentage, icon: Icon, color, helper }: MetricCardProps) {
   return (
-    <motion.div
-      whileHover={{ scale: 1.02, y: -2 }}
-      whileTap={{ scale: 0.98 }}
-      transition={{ duration: 0.2 }}
-    >
-      <Card className="bg-white/50 dark:bg-gray-800/50 backdrop-blur-sm border-gray-200 dark:border-gray-700 hover:shadow-lg transition-all duration-300">
+    <motion.div whileHover={{ scale: 1.02, y: -2 }} whileTap={{ scale: 0.98 }} transition={{ duration: 0.2 }}>
+      <Card className="bg-white/60 dark:bg-gray-800/60 border-gray-200 dark:border-gray-700 backdrop-blur-sm hover:shadow-lg transition-all duration-300">
         <CardContent className="p-6">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center space-x-3">
-              <div className={`p-2 rounded-lg bg-gradient-to-r ${color}`}>
+              <div className={`p-2 rounded-lg ${color}`}>
                 <Icon className="h-5 w-5 text-white" />
               </div>
               <div>
-                <h3 className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                  {title}
-                </h3>
-                <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                  {value}
-                </p>
+                <h3 className="text-sm font-medium text-gray-600 dark:text-gray-400">{title}</h3>
+                <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
               </div>
             </div>
-            
-            {/* Circular Progress */}
             <div className="w-16 h-16">
               <CircularProgressbar
-                value={percentage}
-                text={`${Math.round(percentage)}%`}
+                value={Math.max(0, Math.min(percentage, 100))}
+                text={`${Math.round(Math.max(0, Math.min(percentage, 100)))}%`}
                 styles={buildStyles({
-                  textSize: '20px',
-                  pathColor: color.includes('emerald') ? '#10b981' : 
-                           color.includes('blue') ? '#3b82f6' :
-                           color.includes('purple') ? '#8b5cf6' :
-                           color.includes('amber') ? '#f59e0b' : '#10b981',
-                  textColor: '#374151',
+                  textSize: '18px',
+                  pathColor: '#10b981',
+                  textColor: '#1f2937',
                   trailColor: '#e5e7eb',
                   backgroundColor: '#f3f4f6',
                 })}
               />
             </div>
           </div>
-          
-          {/* Trend Indicator */}
-          {trend && (
-            <div className="flex items-center space-x-2">
-              <Badge 
-                variant={trend.isPositive ? "default" : "destructive"}
-                className={`text-xs ${
-                  trend.isPositive 
-                    ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' 
-                    : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
-                }`}
-              >
-                {trend.isPositive ? '↗' : '↘'} {Math.abs(trend.value)}%
-              </Badge>
-              <span className="text-xs text-gray-500 dark:text-gray-400">
-                vs last month
-              </span>
-            </div>
+          {helper && (
+            <p className="text-xs text-gray-500 dark:text-gray-400">{helper}</p>
           )}
         </CardContent>
       </Card>
@@ -143,26 +109,20 @@ function MetricCard({ title, value, percentage, icon: Icon, color, trend }: Metr
   );
 }
 
-/**
- * Loading skeleton for analytics cards
- */
 function AnalyticsLoading() {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
       {Array.from({ length: 4 }).map((_, index) => (
-        <Card key={index} className="bg-white/50 dark:bg-gray-800/50">
-          <CardContent className="p-6">
-            <div className="flex items-center justify-between mb-4">
-              <div className="flex items-center space-x-3">
-                <Skeleton className="h-9 w-9 rounded-lg" />
-                <div>
-                  <Skeleton className="h-4 w-20 mb-2" />
-                  <Skeleton className="h-6 w-16" />
-                </div>
+        <Card key={index} className="bg-white/60 dark:bg-gray-800/60 border-gray-200 dark:border-gray-700">
+          <CardContent className="p-6 space-y-4">
+            <div className="flex items-center space-x-3">
+              <Skeleton className="h-10 w-10 rounded-lg" />
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-6 w-16" />
               </div>
-              <Skeleton className="h-16 w-16 rounded-full" />
             </div>
-            <Skeleton className="h-6 w-24" />
+            <Skeleton className="h-6 w-full" />
           </CardContent>
         </Card>
       ))}
@@ -170,9 +130,6 @@ function AnalyticsLoading() {
   );
 }
 
-/**
- * Error state component
- */
 function AnalyticsError({ error }: { error: Error }) {
   return (
     <Card className="bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800">
@@ -180,32 +137,22 @@ function AnalyticsError({ error }: { error: Error }) {
         <div className="text-red-600 dark:text-red-400 mb-2">
           <TrendingUp className="h-8 w-8 mx-auto" />
         </div>
-        <h3 className="text-lg font-semibold text-red-800 dark:text-red-200 mb-2">
-          Failed to Load Analytics
-        </h3>
-        <p className="text-red-600 dark:text-red-400 text-sm">
-          {error.message}
-        </p>
+        <h3 className="text-lg font-semibold text-red-800 dark:text-red-200 mb-2">Failed to load analytics</h3>
+        <p className="text-sm text-red-600 dark:text-red-400">{error.message}</p>
       </CardContent>
     </Card>
   );
 }
 
-/**
- * Main Analytics Section Component
- * Displays teacher dashboard analytics with circular progress indicators
- */
 export default function AnalyticsSection() {
   const t = useTranslations('teacher.analytics');
-  
   const { data: analytics, isLoading, error } = useQuery({
     queryKey: ['teacher-analytics'],
     queryFn: fetchAnalytics,
-    refetchInterval: 5 * 60 * 1000, // Refetch every 5 minutes
-    staleTime: 2 * 60 * 1000, // Consider data stale after 2 minutes
+    staleTime: 2 * 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
   });
 
-  // Animation variants for staggered entrance
   const containerVariants = {
     hidden: { opacity: 0 },
     visible: {
@@ -222,10 +169,7 @@ export default function AnalyticsSection() {
     visible: {
       opacity: 1,
       y: 0,
-      transition: {
-        duration: 0.5,
-        ease: 'easeOut',
-      },
+      transition: { duration: 0.4, ease: 'easeOut' },
     },
   };
 
@@ -233,129 +177,127 @@ export default function AnalyticsSection() {
     return <AnalyticsLoading />;
   }
 
-  if (error) {
-    return <AnalyticsError error={error as Error} />;
+  if (error || !analytics) {
+    return <AnalyticsError error={(error ?? new Error('Unknown error')) as Error} />;
   }
 
-  if (!analytics) {
-    return null;
-  }
-
-  // Calculate percentages for progress bars
+  const studentsPercentage = analytics.totalStudents > 0 ? Math.min((analytics.totalStudents / 50) * 100, 100) : 0;
   const completionPercentage = Math.min(analytics.completionRate, 100);
-  const studentsPercentage = Math.min((analytics.totalStudents / 50) * 100, 100); // Assuming max 50 students
-  const interactionsPercentage = Math.min((analytics.hotspotInteractions / 1000) * 100, 100);
-  const sessionsPercentage = Math.min((analytics.gameSessions / 100) * 100, 100);
+  const hotspotPercentage = analytics.hotspotInteractions > 0 ? Math.min((analytics.hotspotInteractions / 1000) * 100, 100) : 0;
+  const sessionsPercentage = analytics.gameSessions > 0 ? Math.min((analytics.gameSessions / 100) * 100, 100) : 0;
 
   return (
     <motion.div
+      className="space-y-6"
       variants={containerVariants}
       initial="hidden"
       animate="visible"
-      className="space-y-6"
     >
-      {/* Main Metrics Grid */}
-      <motion.div 
-        variants={itemVariants}
-        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6"
-      >
+      <motion.div variants={itemVariants} className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <MetricCard
           title={t('totalStudents', { defaultValue: 'Total Students' })}
           value={analytics.totalStudents}
           percentage={studentsPercentage}
           icon={Users}
-          color="from-emerald-500 to-teal-500"
-          trend={{
-            value: analytics.monthlyGrowth,
-            isPositive: analytics.monthlyGrowth > 0,
-          }}
+          color="bg-emerald-500"
+          helper={t('totalStudentsHelper', { defaultValue: 'Across all active classes' })}
         />
-        
         <MetricCard
           title={t('completionRate', { defaultValue: 'Completion Rate' })}
-          value={`${analytics.completionRate}%`}
+          value={`${analytics.completionRate.toFixed(1)}%`}
           percentage={completionPercentage}
           icon={Target}
-          color="from-blue-500 to-indigo-500"
-          trend={{
-            value: analytics.weeklyProgress,
-            isPositive: analytics.weeklyProgress > 0,
-          }}
+          color="bg-blue-500"
+          helper={t('completionRateHelper', { defaultValue: 'Assignments completed this week' })}
         />
-        
         <MetricCard
           title={t('hotspotInteractions', { defaultValue: 'Hotspot Interactions' })}
           value={analytics.hotspotInteractions.toLocaleString()}
-          percentage={interactionsPercentage}
+          percentage={hotspotPercentage}
           icon={Zap}
-          color="from-purple-500 to-pink-500"
+          color="bg-purple-500"
+          helper={t('hotspotHelper', { defaultValue: 'Student engagement with interactive content' })}
         />
-        
         <MetricCard
           title={t('gameSessions', { defaultValue: 'Game Sessions' })}
           value={analytics.gameSessions}
           percentage={sessionsPercentage}
           icon={Award}
-          color="from-amber-500 to-orange-500"
+          color="bg-amber-500"
+          helper={t('gameSessionsHelper', { defaultValue: 'Sessions recorded across learning games' })}
         />
       </motion.div>
 
-      {/* Additional Metrics */}
-      <motion.div 
-        variants={itemVariants}
-        className="grid grid-cols-1 md:grid-cols-3 gap-6"
-      >
+      <motion.div variants={itemVariants} className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <Card className="bg-gradient-to-r from-emerald-500/10 to-teal-500/10 border-emerald-200 dark:border-emerald-800">
-          <CardContent className="p-6">
-            <div className="flex items-center space-x-3">
-              <div className="p-2 bg-emerald-500 rounded-lg">
-                <Star className="h-5 w-5 text-white" />
-              </div>
-              <div>
-                <h3 className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
-                  {t('averageScore', { defaultValue: 'Average Score' })}
-                </h3>
-                <p className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">
-                  {analytics.averageScore}%
-                </p>
-              </div>
+          <CardContent className="p-6 flex items-center space-x-3">
+            <div className="p-2 bg-emerald-500 rounded-lg">
+              <BookOpen className="h-5 w-5 text-white" />
+            </div>
+            <div>
+              <h3 className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
+                {t('averageScore', { defaultValue: 'Average Score' })}
+              </h3>
+              <p className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">
+                {analytics.averageScore.toFixed(1)}%
+              </p>
             </div>
           </CardContent>
         </Card>
-        
+
         <Card className="bg-gradient-to-r from-blue-500/10 to-indigo-500/10 border-blue-200 dark:border-blue-800">
-          <CardContent className="p-6">
-            <div className="flex items-center space-x-3">
-              <div className="p-2 bg-blue-500 rounded-lg">
-                <BookOpen className="h-5 w-5 text-white" />
-              </div>
-              <div>
-                <h3 className="text-sm font-medium text-blue-700 dark:text-blue-300">
-                  {t('highScores', { defaultValue: 'High Scores' })}
-                </h3>
-                <p className="text-2xl font-bold text-blue-900 dark:text-blue-100">
-                  {analytics.highScores}
-                </p>
-              </div>
+          <CardContent className="p-6 flex items-center space-x-3">
+            <div className="p-2 bg-blue-500 rounded-lg">
+              <ClipboardList className="h-5 w-5 text-white" />
+            </div>
+            <div>
+              <h3 className="text-sm font-medium text-blue-700 dark:text-blue-300">
+                {t('activeAssignments', { defaultValue: 'Active Assignments' })}
+              </h3>
+              <p className="text-2xl font-bold text-blue-900 dark:text-blue-100">
+                {analytics.activeAssignments}
+              </p>
             </div>
           </CardContent>
         </Card>
-        
-        <Card className="bg-gradient-to-r from-purple-500/10 to-pink-500/10 border-purple-200 dark:border-purple-800">
-          <CardContent className="p-6">
+
+        <Card className="bg-gradient-to-r from-yellow-500/10 to-orange-500/10 border-yellow-200 dark:border-yellow-800">
+          <CardContent className="p-6 flex items-center space-x-3">
+            <div className="p-2 bg-amber-500 rounded-lg">
+              <TrendingUp className="h-5 w-5 text-white" />
+            </div>
+            <div>
+              <h3 className="text-sm font-medium text-amber-700 dark:text-amber-300">
+                {t('highScores', { defaultValue: 'High Scores' })}
+              </h3>
+              <p className="text-2xl font-bold text-amber-900 dark:text-amber-100">
+                {analytics.highScores}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-gradient-to-r from-rose-500/10 to-red-500/10 border-rose-200 dark:border-rose-800">
+          <CardContent className="p-6 flex items-center justify-between">
             <div className="flex items-center space-x-3">
-              <div className="p-2 bg-purple-500 rounded-lg">
+              <div className="p-2 bg-rose-500 rounded-lg">
                 <Clock className="h-5 w-5 text-white" />
               </div>
               <div>
-                <h3 className="text-sm font-medium text-purple-700 dark:text-purple-300">
-                  {t('weeklyProgress', { defaultValue: 'Weekly Progress' })}
+                <h3 className="text-sm font-medium text-rose-700 dark:text-rose-300">
+                  {t('pendingReviews', { defaultValue: 'Pending Reviews' })}
                 </h3>
-                <p className="text-2xl font-bold text-purple-900 dark:text-purple-100">
-                  +{analytics.weeklyProgress}%
+                <p className="text-2xl font-bold text-rose-900 dark:text-rose-100">
+                  {analytics.pendingSubmissions}
                 </p>
               </div>
             </div>
+            {analytics.lastUpdated && (
+              <Badge variant="secondary" className="text-xs bg-white/60 dark:bg-gray-900/60">
+                {t('updated', { defaultValue: 'Updated' })}{' '}
+                {new Date(analytics.lastUpdated).toLocaleTimeString()}
+              </Badge>
+            )}
           </CardContent>
         </Card>
       </motion.div>

--- a/apps/web/src/components/teacher/ClassSection.tsx
+++ b/apps/web/src/components/teacher/ClassSection.tsx
@@ -1,11 +1,8 @@
-/* AlFawz Qur'an Institute — generated with TRAE */
-/* Author: Auto-scaffold (review required) */
-
 'use client';
 
-import React, { useState, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { motion, AnimatePresence } from 'framer-motion';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -14,23 +11,15 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { 
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import { 
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { 
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -41,21 +30,24 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import { 
-  Users, 
-  Plus, 
-  Edit, 
-  Trash2, 
-  BookOpen,
+import {
+  Users,
+  Plus,
+  Edit,
+  Trash2,
   Calendar,
-  UserPlus,
-  UserMinus,
-  GraduationCap,
-  Clock,
-  Target
+  BookOpen,
 } from 'lucide-react';
+import { api } from '@/lib/api';
 
-// Types for class data
+interface Student {
+  id: string;
+  name: string;
+  email: string;
+  joinedAt?: string;
+  progress?: number;
+}
+
 interface ClassData {
   id: string;
   title: string;
@@ -64,14 +56,6 @@ interface ClassData {
   studentCount: number;
   createdAt: string;
   students: Student[];
-}
-
-interface Student {
-  id: string;
-  name: string;
-  email: string;
-  joinedAt: string;
-  progress: number;
 }
 
 interface CreateClassData {
@@ -87,113 +71,132 @@ interface AvailableStudent {
   email: string;
 }
 
-/**
- * Fetch teacher's classes from API
- * @returns Promise with classes data
- */
+const LEVEL_OPTIONS: Record<1 | 2 | 3, string> = {
+  1: 'teacher.classes.levels.beginner',
+  2: 'teacher.classes.levels.intermediate',
+  3: 'teacher.classes.levels.advanced',
+};
+
+const normalizeLevel = (value: number): 1 | 2 | 3 => {
+  if (value <= 1) return 1;
+  if (value >= 3) return 3;
+  return 2;
+};
+
+const transformClass = (classData: any): ClassData => {
+  const members: any[] =
+    Array.isArray(classData.members) ? classData.members : Array.isArray(classData.students) ? classData.students : [];
+
+  const students: Student[] = members
+    .filter((member) => {
+      const role = member?.pivot?.role_in_class ?? member?.role_in_class ?? 'student';
+      return role === 'student';
+    })
+    .map((member) => ({
+      id: String(member.id),
+      name: member.name ?? 'Student',
+      email: member.email ?? '',
+      joinedAt: member?.pivot?.created_at ?? member?.joined_at ?? undefined,
+      progress: member?.progress ?? member?.pivot?.progress ?? undefined,
+    }));
+
+  return {
+    id: String(classData.id),
+    title: classData.title ?? classData.name ?? 'Untitled Class',
+    description: classData.description ?? '',
+    level: normalizeLevel(Number(classData.level ?? 1) as 1 | 2 | 3),
+    studentCount: students.length,
+    createdAt: classData.created_at ?? new Date().toISOString(),
+    students,
+  };
+};
+
 const fetchClasses = async (): Promise<ClassData[]> => {
-  const response = await fetch('/api/teacher/classes', {
-    headers: {
-      'Authorization': `Bearer ${localStorage.getItem('auth_token')}`,
-      'Content-Type': 'application/json',
-    },
-  });
-  
-  if (!response.ok) {
-    throw new Error('Failed to fetch classes');
-  }
-  
-  const data = await response.json();
-  return data.classes;
+  const response = await api.get('/classes');
+  const payload = response as any;
+  const rawClasses = Array.isArray(payload.data) ? payload.data : Array.isArray(payload?.data?.data) ? payload.data.data : [];
+
+  return rawClasses.map(transformClass);
 };
 
-/**
- * Fetch available students for class assignment
- * @returns Promise with available students
- */
 const fetchAvailableStudents = async (): Promise<AvailableStudent[]> => {
-  const response = await fetch('/api/teacher/students/available', {
-    headers: {
-      'Authorization': `Bearer ${localStorage.getItem('auth_token')}`,
-      'Content-Type': 'application/json',
-    },
-  });
-  
-  if (!response.ok) {
-    throw new Error('Failed to fetch available students');
+  const response = await api.get('/profile/my-students');
+  const payload = (response as any)?.students ?? (response as any)?.data?.students ?? [];
+
+  if (!Array.isArray(payload)) {
+    return [];
   }
-  
-  const data = await response.json();
-  return data.students;
+
+  return payload.map((student: any) => ({
+    id: String(student.id),
+    name: student.name ?? 'Student',
+    email: student.email ?? '',
+  }));
 };
 
-/**
- * Create new class
- * @param classData - Class creation data
- */
-const createClass = async (classData: CreateClassData): Promise<ClassData> => {
-  const response = await fetch('/api/teacher/classes', {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${localStorage.getItem('auth_token')}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(classData),
-  });
-  
-  if (!response.ok) {
-    throw new Error('Failed to create class');
+const createClass = async (data: CreateClassData): Promise<ClassData> => {
+  const { studentIds, ...classPayload } = data;
+  const response = await api.post('/classes', classPayload);
+  const created = (response as any)?.class ?? (response as any)?.data?.class ?? response;
+  const newClass = transformClass(created);
+
+  if (studentIds.length > 0) {
+    await Promise.all(
+      studentIds.map((studentId) =>
+        api.post(`/classes/${newClass.id}/members`, {
+          user_id: Number(studentId),
+          role_in_class: 'student',
+        }),
+      ),
+    );
   }
-  
-  return response.json();
+
+  const refreshed = await api.get(`/classes/${newClass.id}`);
+  const refreshedClass = (refreshed as any)?.class ?? (refreshed as any)?.data?.class ?? newClass;
+  return transformClass(refreshedClass);
 };
 
-/**
- * Update existing class
- * @param classId - Class ID
- * @param classData - Updated class data
- */
-const updateClass = async (classId: string, classData: Partial<CreateClassData>): Promise<ClassData> => {
-  const response = await fetch(`/api/teacher/classes/${classId}`, {
-    method: 'PUT',
-    headers: {
-      'Authorization': `Bearer ${localStorage.getItem('auth_token')}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(classData),
-  });
-  
-  if (!response.ok) {
-    throw new Error('Failed to update class');
+const updateClass = async (classId: string, data: CreateClassData): Promise<ClassData> => {
+  const { studentIds, ...classPayload } = data;
+  const payloadKeys = Object.keys(classPayload).filter((key) => key !== 'studentIds');
+
+  if (payloadKeys.length > 0) {
+    await api.put(`/classes/${classId}`, classPayload);
   }
-  
-  return response.json();
+
+  const detailsResponse = await api.get(`/classes/${classId}`);
+  const details = (detailsResponse as any)?.class ?? (detailsResponse as any)?.data?.class ?? detailsResponse;
+  const currentClass = transformClass(details);
+  const existingIds = currentClass.students.map((student) => student.id);
+
+  const toAdd = studentIds.filter((id) => !existingIds.includes(id));
+  const toRemove = existingIds.filter((id) => !studentIds.includes(id));
+
+  if (toAdd.length > 0) {
+    await Promise.all(
+      toAdd.map((studentId) =>
+        api.post(`/classes/${classId}/members`, {
+          user_id: Number(studentId),
+          role_in_class: 'student',
+        }),
+      ),
+    );
+  }
+
+  for (const studentId of toRemove) {
+    await api.delete(`/classes/${classId}/members/${studentId}`);
+  }
+
+  const refreshed = await api.get(`/classes/${classId}`);
+  const refreshedClass = (refreshed as any)?.class ?? (refreshed as any)?.data?.class ?? details;
+  return transformClass(refreshedClass);
 };
 
-/**
- * Delete class
- * @param classId - Class ID to delete
- */
-const deleteClass = async (classId: string): Promise<void> => {
-  const response = await fetch(`/api/teacher/classes/${classId}`, {
-    method: 'DELETE',
-    headers: {
-      'Authorization': `Bearer ${localStorage.getItem('auth_token')}`,
-      'Content-Type': 'application/json',
-    },
-  });
-  
-  if (!response.ok) {
-    throw new Error('Failed to delete class');
-  }
+const deleteClass = async (classId: string) => {
+  await api.delete(`/classes/${classId}`);
 };
 
-/**
- * Get level badge color
- * @param level - Class level (1, 2, or 3)
- * @returns CSS classes for badge styling
- */
-function getLevelBadgeColor(level: 1 | 2 | 3) {
+const getLevelBadgeColor = (level: 1 | 2 | 3) => {
   switch (level) {
     case 1:
       return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
@@ -204,14 +207,8 @@ function getLevelBadgeColor(level: 1 | 2 | 3) {
     default:
       return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200';
   }
-}
+};
 
-/**
- * Class creation/editing form component
- * @param isOpen - Dialog open state
- * @param onClose - Close dialog callback
- * @param editingClass - Class being edited (null for creation)
- */
 interface ClassFormProps {
   isOpen: boolean;
   onClose: () => void;
@@ -221,7 +218,7 @@ interface ClassFormProps {
 function ClassForm({ isOpen, onClose, editingClass }: ClassFormProps) {
   const t = useTranslations('teacher.classes');
   const queryClient = useQueryClient();
-  
+
   const [formData, setFormData] = useState<CreateClassData>({
     title: '',
     description: '',
@@ -230,27 +227,22 @@ function ClassForm({ isOpen, onClose, editingClass }: ClassFormProps) {
   });
 
   const { data: availableStudents = [] } = useQuery({
-    queryKey: ['available-students'],
+    queryKey: ['teacher-available-students'],
     queryFn: fetchAvailableStudents,
     enabled: isOpen,
+    staleTime: 5 * 60 * 1000,
   });
 
-  // Populate form when editing
   useEffect(() => {
     if (editingClass) {
       setFormData({
         title: editingClass.title,
         description: editingClass.description,
         level: editingClass.level,
-        studentIds: editingClass.students.map(s => s.id),
+        studentIds: editingClass.students.map((student) => student.id),
       });
     } else {
-      setFormData({
-        title: '',
-        description: '',
-        level: 1,
-        studentIds: [],
-      });
+      setFormData({ title: '', description: '', level: 1, studentIds: [] });
     }
   }, [editingClass, isOpen]);
 
@@ -263,17 +255,15 @@ function ClassForm({ isOpen, onClose, editingClass }: ClassFormProps) {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ classId, data }: { classId: string; data: Partial<CreateClassData> }) => 
-      updateClass(classId, data),
+    mutationFn: ({ classId, data }: { classId: string; data: CreateClassData }) => updateClass(classId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['teacher-classes'] });
       onClose();
     },
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
     if (editingClass) {
       updateMutation.mutate({ classId: editingClass.id, data: formData });
     } else {
@@ -281,11 +271,11 @@ function ClassForm({ isOpen, onClose, editingClass }: ClassFormProps) {
     }
   };
 
-  const handleStudentToggle = (studentId: string) => {
-    setFormData(prev => ({
+  const toggleStudent = (studentId: string) => {
+    setFormData((prev) => ({
       ...prev,
       studentIds: prev.studentIds.includes(studentId)
-        ? prev.studentIds.filter(id => id !== studentId)
+        ? prev.studentIds.filter((id) => id !== studentId)
         : [...prev.studentIds, studentId],
     }));
   };
@@ -295,21 +285,17 @@ function ClassForm({ isOpen, onClose, editingClass }: ClassFormProps) {
       <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
-            {editingClass 
+            {editingClass
               ? t('form.editTitle', { defaultValue: 'Edit Class' })
-              : t('form.createTitle', { defaultValue: 'Create New Class' })
-            }
+              : t('form.createTitle', { defaultValue: 'Create New Class' })}
           </DialogTitle>
           <DialogDescription>
-            {editingClass 
-              ? t('form.editDescription', { defaultValue: 'Update class details and manage students' })
-              : t('form.createDescription', { defaultValue: 'Create a new class and assign students' })
-            }
+            {editingClass
+              ? t('form.editDescription', { defaultValue: 'Update class details and manage students.' })
+              : t('form.createDescription', { defaultValue: 'Create a new class and assign students.' })}
           </DialogDescription>
         </DialogHeader>
-        
         <form onSubmit={handleSubmit} className="space-y-6">
-          {/* Basic Info */}
           <div className="space-y-4">
             <div>
               <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -317,92 +303,88 @@ function ClassForm({ isOpen, onClose, editingClass }: ClassFormProps) {
               </label>
               <Input
                 value={formData.title}
-                onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
+                onChange={(event) => setFormData((prev) => ({ ...prev, title: event.target.value }))}
                 placeholder={t('form.titlePlaceholder', { defaultValue: 'Enter class title' })}
                 required
               />
             </div>
-            
             <div>
               <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                 {t('form.description', { defaultValue: 'Description' })}
               </label>
               <Textarea
                 value={formData.description}
-                onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+                onChange={(event) => setFormData((prev) => ({ ...prev, description: event.target.value }))}
                 placeholder={t('form.descriptionPlaceholder', { defaultValue: 'Enter class description' })}
                 rows={3}
               />
             </div>
-            
             <div>
               <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                 {t('form.level', { defaultValue: 'Level' })}
               </label>
-              <Select 
-                value={formData.level.toString()} 
-                onValueChange={(value) => setFormData(prev => ({ ...prev, level: parseInt(value) as 1 | 2 | 3 }))}
+              <Select
+                value={formData.level.toString()}
+                onValueChange={(value) => setFormData((prev) => ({ ...prev, level: parseInt(value, 10) as 1 | 2 | 3 }))}
               >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="1">{t('levels.beginner', { defaultValue: 'Level 1 - Beginner' })}</SelectItem>
-                  <SelectItem value="2">{t('levels.intermediate', { defaultValue: 'Level 2 - Intermediate' })}</SelectItem>
-                  <SelectItem value="3">{t('levels.advanced', { defaultValue: 'Level 3 - Advanced' })}</SelectItem>
+                  {([1, 2, 3] as const).map((level) => (
+                    <SelectItem key={level} value={level.toString()}>
+                      {t(LEVEL_OPTIONS[level], { defaultValue: `Level ${level}` })}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
           </div>
-
-          {/* Student Selection */}
           <div>
             <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3 block">
               {t('form.students', { defaultValue: 'Select Students' })} ({formData.studentIds.length})
             </label>
             <ScrollArea className="h-48 border rounded-lg p-3">
               <div className="space-y-2">
-                {availableStudents.map((student) => (
-                  <div 
-                    key={student.id}
-                    className={`flex items-center justify-between p-2 rounded-lg cursor-pointer transition-colors ${
-                      formData.studentIds.includes(student.id)
-                        ? 'bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800'
-                        : 'bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700'
-                    }`}
-                    onClick={() => handleStudentToggle(student.id)}
-                  >
-                    <div>
-                      <p className="text-sm font-medium text-gray-900 dark:text-white">
-                        {student.name}
-                      </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
-                        {student.email}
-                      </p>
+                {availableStudents.map((student) => {
+                  const selected = formData.studentIds.includes(student.id);
+                  return (
+                    <div
+                      key={student.id}
+                      className={`flex items-center justify-between p-2 rounded-lg cursor-pointer transition-colors ${
+                        selected
+                          ? 'bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800'
+                          : 'bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700'
+                      }`}
+                      onClick={() => toggleStudent(student.id)}
+                    >
+                      <div>
+                        <p className="text-sm font-medium text-gray-900 dark:text-white">{student.name}</p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">{student.email}</p>
+                      </div>
+                      {selected && (
+                        <Badge className="bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200">
+                          {t('form.selected', { defaultValue: 'Selected' })}
+                        </Badge>
+                      )}
                     </div>
-                    {formData.studentIds.includes(student.id) && (
-                      <Badge className="bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200">
-                        Selected
-                      </Badge>
-                    )}
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </ScrollArea>
           </div>
-
           <DialogFooter>
             <Button type="button" variant="outline" onClick={onClose}>
               {t('form.cancel', { defaultValue: 'Cancel' })}
             </Button>
-            <Button 
-              type="submit" 
+            <Button
+              type="submit"
               disabled={createMutation.isPending || updateMutation.isPending}
+              className="bg-emerald-600 hover:bg-emerald-700"
             >
-              {editingClass 
+              {editingClass
                 ? t('form.update', { defaultValue: 'Update Class' })
-                : t('form.create', { defaultValue: 'Create Class' })
-              }
+                : t('form.create', { defaultValue: 'Create Class' })}
             </Button>
           </DialogFooter>
         </form>
@@ -411,12 +393,6 @@ function ClassForm({ isOpen, onClose, editingClass }: ClassFormProps) {
   );
 }
 
-/**
- * Individual class card component
- * @param classData - Class data
- * @param onEdit - Edit callback
- * @param onDelete - Delete callback
- */
 interface ClassCardProps {
   classData: ClassData;
   onEdit: (classData: ClassData) => void;
@@ -425,7 +401,17 @@ interface ClassCardProps {
 
 function ClassCard({ classData, onEdit, onDelete }: ClassCardProps) {
   const t = useTranslations('teacher.classes');
-  
+  const formattedDate = useMemo(() => {
+    try {
+      return new Date(classData.createdAt).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch (error) {
+      return classData.createdAt;
+    }
+  }, [classData.createdAt]);
+
   return (
     <motion.div
       layout
@@ -435,81 +421,59 @@ function ClassCard({ classData, onEdit, onDelete }: ClassCardProps) {
       whileHover={{ y: -2 }}
       className="group"
     >
-      <Card className="bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm border-gray-200 dark:border-gray-700 hover:shadow-lg transition-all duration-300">
+      <Card className="bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm border-gray-200 dark:border-gray-700 hover:shadow-lg transition-all duration-300 h-full">
         <CardHeader className="pb-3">
           <div className="flex items-start justify-between">
             <div className="flex-1">
               <CardTitle className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
                 {classData.title}
               </CardTitle>
-              <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
-                {classData.description}
-              </p>
+              <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">{classData.description}</p>
             </div>
-            
-            <div className="flex items-center space-x-2 ml-4">
-              <Badge className={getLevelBadgeColor(classData.level)}>
-                {t(`levels.${classData.level}`, { defaultValue: `Level ${classData.level}` })}
-              </Badge>
-            </div>
+            <Badge className={getLevelBadgeColor(classData.level)}>
+              {t(LEVEL_OPTIONS[classData.level], { defaultValue: `Level ${classData.level}` })}
+            </Badge>
           </div>
         </CardHeader>
-        
-        <CardContent>
-          {/* Stats */}
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex items-center space-x-4 text-sm text-gray-600 dark:text-gray-400">
-              <div className="flex items-center space-x-1">
-                <Users className="h-4 w-4" />
-                <span>{classData.studentCount} {t('students', { defaultValue: 'students' })}</span>
-              </div>
-              <div className="flex items-center space-x-1">
-                <Calendar className="h-4 w-4" />
-                <span>
-                  {new Date(classData.createdAt).toLocaleDateString('en-US', { 
-                    month: 'short', 
-                    day: 'numeric' 
-                  })}
-                </span>
-              </div>
+        <CardContent className="flex flex-col justify-between h-full">
+          <div className="flex items-center justify-between mb-4 text-sm text-gray-600 dark:text-gray-400">
+            <div className="flex items-center space-x-1">
+              <Users className="h-4 w-4" />
+              <span>
+                {classData.studentCount} {t('students', { defaultValue: 'students' })}
+              </span>
+            </div>
+            <div className="flex items-center space-x-1">
+              <Calendar className="h-4 w-4" />
+              <span>{formattedDate}</span>
             </div>
           </div>
-
-          {/* Actions */}
           <div className="flex items-center justify-between">
             <Button variant="ghost" size="sm" className="text-blue-600 hover:text-blue-700">
               <BookOpen className="h-4 w-4 mr-2" />
               {t('viewDetails', { defaultValue: 'View Details' })}
             </Button>
-            
             <div className="flex items-center space-x-1 opacity-0 group-hover:opacity-100 transition-opacity">
-              <Button 
-                variant="ghost" 
+              <Button
+                variant="ghost"
                 size="sm"
                 onClick={() => onEdit(classData)}
                 className="text-gray-600 hover:text-blue-600"
               >
                 <Edit className="h-4 w-4" />
               </Button>
-              
               <AlertDialog>
                 <AlertDialogTrigger asChild>
-                  <Button 
-                    variant="ghost" 
-                    size="sm"
-                    className="text-gray-600 hover:text-red-600"
-                  >
+                  <Button variant="ghost" size="sm" className="text-gray-600 hover:text-red-600">
                     <Trash2 className="h-4 w-4" />
                   </Button>
                 </AlertDialogTrigger>
                 <AlertDialogContent>
                   <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      {t('deleteDialog.title', { defaultValue: 'Delete Class' })}
-                    </AlertDialogTitle>
+                    <AlertDialogTitle>{t('deleteDialog.title', { defaultValue: 'Delete Class' })}</AlertDialogTitle>
                     <AlertDialogDescription>
-                      {t('deleteDialog.description', { 
-                        defaultValue: 'Are you sure you want to delete this class? This action cannot be undone.' 
+                      {t('deleteDialog.description', {
+                        defaultValue: 'Are you sure you want to delete this class? This action cannot be undone.',
                       })}
                     </AlertDialogDescription>
                   </AlertDialogHeader>
@@ -517,10 +481,7 @@ function ClassCard({ classData, onEdit, onDelete }: ClassCardProps) {
                     <AlertDialogCancel>
                       {t('deleteDialog.cancel', { defaultValue: 'Cancel' })}
                     </AlertDialogCancel>
-                    <AlertDialogAction 
-                      onClick={() => onDelete(classData.id)}
-                      className="bg-red-600 hover:bg-red-700"
-                    >
+                    <AlertDialogAction onClick={() => onDelete(classData.id)} className="bg-red-600 hover:bg-red-700">
                       {t('deleteDialog.confirm', { defaultValue: 'Delete' })}
                     </AlertDialogAction>
                   </AlertDialogFooter>
@@ -534,34 +495,18 @@ function ClassCard({ classData, onEdit, onDelete }: ClassCardProps) {
   );
 }
 
-/**
- * Loading skeleton for classes
- */
 function ClassesLoading() {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-      {Array.from({ length: 6 }).map((_, index) => (
-        <Card key={index} className="bg-white/70 dark:bg-gray-800/70">
-          <CardHeader>
-            <div className="flex items-start justify-between">
-              <div className="flex-1">
-                <Skeleton className="h-6 w-3/4 mb-2" />
-                <Skeleton className="h-4 w-full" />
-              </div>
-              <Skeleton className="h-6 w-16 ml-4" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-between mb-4">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-20" />
-            </div>
-            <div className="flex items-center justify-between">
-              <Skeleton className="h-8 w-24" />
-              <div className="flex space-x-1">
-                <Skeleton className="h-8 w-8" />
-                <Skeleton className="h-8 w-8" />
-              </div>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <Card key={index} className="bg-white/70 dark:bg-gray-800/70 border-gray-200 dark:border-gray-700">
+          <CardContent className="p-6 space-y-4">
+            <Skeleton className="h-6 w-3/4" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+            <div className="flex items-center space-x-4">
+              <Skeleton className="h-4 w-1/4" />
+              <Skeleton className="h-4 w-1/4" />
             </div>
           </CardContent>
         </Card>
@@ -570,72 +515,61 @@ function ClassesLoading() {
   );
 }
 
-/**
- * Empty state component
- */
 function EmptyClasses({ onCreateClass }: { onCreateClass: () => void }) {
   const t = useTranslations('teacher.classes');
-  
   return (
-    <div className="text-center py-12">
-      <div className="text-gray-400 dark:text-gray-600 mb-4">
-        <GraduationCap className="h-16 w-16 mx-auto" />
-      </div>
-      <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
-        {t('empty.title', { defaultValue: 'No Classes Yet' })}
-      </h3>
-      <p className="text-gray-600 dark:text-gray-400 mb-6 max-w-md mx-auto">
-        {t('empty.description', { 
-          defaultValue: 'Create your first class to start managing students and assignments.' 
-        })}
-      </p>
-      <Button onClick={onCreateClass} className="bg-emerald-600 hover:bg-emerald-700">
-        <Plus className="h-4 w-4 mr-2" />
-        {t('createFirst', { defaultValue: 'Create Your First Class' })}
-      </Button>
-    </div>
+    <Card className="bg-white/70 dark:bg-gray-800/70 border-gray-200 dark:border-gray-700">
+      <CardContent className="p-10 text-center space-y-4">
+        <div className="mx-auto h-12 w-12 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center">
+          <Users className="h-6 w-6 text-emerald-600" />
+        </div>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          {t('empty.title', { defaultValue: 'No classes yet' })}
+        </h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          {t('empty.subtitle', { defaultValue: 'Create your first class to start organizing your students.' })}
+        </p>
+        <Button onClick={onCreateClass} className="bg-emerald-600 hover:bg-emerald-700">
+          <Plus className="h-4 w-4 mr-2" />
+          {t('create', { defaultValue: 'Create Class' })}
+        </Button>
+      </CardContent>
+    </Card>
   );
 }
 
-/**
- * Main Class Section Component
- * Displays and manages teacher's classes with CRUD operations
- */
 export default function ClassSection() {
   const t = useTranslations('teacher.classes');
   const queryClient = useQueryClient();
-  
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingClass, setEditingClass] = useState<ClassData | null>(null);
 
-  const { data: classes = [], isLoading, error } = useQuery({
+  const {
+    data: classes = [],
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ['teacher-classes'],
     queryFn: fetchClasses,
-    refetchInterval: 2 * 60 * 1000, // Refetch every 2 minutes
+    refetchInterval: 2 * 60 * 1000,
   });
 
   const deleteMutation = useMutation({
     mutationFn: deleteClass,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['teacher-classes'] });
-    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['teacher-classes'] }),
   });
 
-  const handleCreateClass = () => {
+  const openCreateForm = () => {
     setEditingClass(null);
     setIsFormOpen(true);
   };
 
-  const handleEditClass = (classData: ClassData) => {
+  const openEditForm = (classData: ClassData) => {
     setEditingClass(classData);
     setIsFormOpen(true);
   };
 
-  const handleDeleteClass = (classId: string) => {
-    deleteMutation.mutate(classId);
-  };
-
-  const handleCloseForm = () => {
+  const closeForm = () => {
     setIsFormOpen(false);
     setEditingClass(null);
   };
@@ -654,9 +588,7 @@ export default function ClassSection() {
           <h3 className="text-lg font-semibold text-red-800 dark:text-red-200 mb-2">
             {t('error.title', { defaultValue: 'Failed to Load Classes' })}
           </h3>
-          <p className="text-red-600 dark:text-red-400 text-sm">
-            {(error as Error).message}
-          </p>
+          <p className="text-red-600 dark:text-red-400 text-sm">{(error as Error).message}</p>
         </CardContent>
       </Card>
     );
@@ -665,37 +597,30 @@ export default function ClassSection() {
   if (classes.length === 0) {
     return (
       <>
-        <EmptyClasses onCreateClass={handleCreateClass} />
-        <ClassForm 
-          isOpen={isFormOpen} 
-          onClose={handleCloseForm} 
-          editingClass={editingClass}
-        />
+        <EmptyClasses onCreateClass={openCreateForm} />
+        <ClassForm isOpen={isFormOpen} onClose={closeForm} editingClass={editingClass} />
       </>
     );
   }
 
   return (
     <div className="space-y-6">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
             {t('title', { defaultValue: 'My Classes' })}
           </h3>
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            {t('subtitle', { defaultValue: `Managing ${classes.length} classes` })}
+            {t('subtitle', { defaultValue: `Managing ${classes.length} classes`, count: classes.length })}
           </p>
         </div>
-        
-        <Button onClick={handleCreateClass} className="bg-emerald-600 hover:bg-emerald-700">
+        <Button onClick={openCreateForm} className="bg-emerald-600 hover:bg-emerald-700">
           <Plus className="h-4 w-4 mr-2" />
           {t('create', { defaultValue: 'Create Class' })}
         </Button>
       </div>
 
-      {/* Classes Grid */}
-      <motion.div 
+      <motion.div
         className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
@@ -703,22 +628,12 @@ export default function ClassSection() {
       >
         <AnimatePresence>
           {classes.map((classData) => (
-            <ClassCard
-              key={classData.id}
-              classData={classData}
-              onEdit={handleEditClass}
-              onDelete={handleDeleteClass}
-            />
+            <ClassCard key={classData.id} classData={classData} onEdit={openEditForm} onDelete={(id) => deleteMutation.mutate(id)} />
           ))}
         </AnimatePresence>
       </motion.div>
 
-      {/* Form Dialog */}
-      <ClassForm 
-        isOpen={isFormOpen} 
-        onClose={handleCloseForm} 
-        editingClass={editingClass}
-      />
+      <ClassForm isOpen={isFormOpen} onClose={closeForm} editingClass={editingClass} />
     </div>
   );
 }

--- a/apps/web/src/components/teacher/GameAnalyticsSection.tsx
+++ b/apps/web/src/components/teacher/GameAnalyticsSection.tsx
@@ -1,762 +1,254 @@
-/* AlFawz Qur'an Institute — generated with TRAE */
-/* Author: Auto-scaffold (review required) */
-
 'use client';
 
-import React, { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { useTranslations } from 'next-intl';
+import React from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
+import { useTranslations } from 'next-intl';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { 
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { 
-  Gamepad2, 
-  Trophy, 
-  Target, 
-  Clock, 
-  Users, 
-  TrendingUp, 
-  TrendingDown, 
-  Star, 
-  Award, 
-  Zap, 
-  BarChart3, 
-  PieChart, 
-  Activity, 
-  Calendar, 
-  Filter,
-  Download,
-  RefreshCw
-} from 'lucide-react';
+import { api } from '@/lib/api';
+import { Gamepad2, Target, Trophy, Users, BarChart3 } from 'lucide-react';
 
-// Types for game analytics data
-interface GameAnalytics {
-  overview: GameOverview;
-  topPerformers: TopPerformer[];
-  gameStats: GameStats[];
-  engagementMetrics: EngagementMetrics;
-  progressTrends: ProgressTrend[];
+interface RawGameAnalytics {
+  total_sessions?: number;
+  average_session_duration?: string;
+  most_popular_game?: string;
+  top_performers?: { name: string; score: number; level: string }[];
+  weekly_activity?: { day: string; sessions: number }[];
+  game_types?: { name: string; sessions: number; avg_score: number }[];
 }
 
-interface GameOverview {
+interface GameAnalyticsSummary {
   totalSessions: number;
-  averageScore: number;
-  completionRate: number;
-  activeStudents: number;
-  totalPlayTime: number;
-  highestScore: number;
+  averageSessionDuration: string;
+  mostPopularGame: string;
+  topPerformers: { name: string; score: number; level: string }[];
+  weeklyActivity: { day: string; sessions: number }[];
+  gameTypes: { name: string; sessions: number; avgScore: number }[];
 }
 
-interface TopPerformer {
-  id: string;
-  name: string;
-  avatar?: string;
-  score: number;
-  gamesPlayed: number;
-  averageScore: number;
-  rank: number;
-  badges: string[];
-}
+const fetchGameAnalytics = async (): Promise<GameAnalyticsSummary> => {
+  const response = await api.get('/teacher/game-analytics');
+  const payload = response as RawGameAnalytics;
 
-interface GameStats {
-  gameType: string;
-  sessionsPlayed: number;
-  averageScore: number;
-  completionRate: number;
-  averageTime: number;
-  difficulty: 'easy' | 'medium' | 'hard';
-  popularity: number;
-}
-
-interface EngagementMetrics {
-  dailyActive: number;
-  weeklyActive: number;
-  monthlyActive: number;
-  retentionRate: number;
-  averageSessionTime: number;
-  peakHours: { hour: number; sessions: number }[];
-}
-
-interface ProgressTrend {
-  date: string;
-  sessions: number;
-  averageScore: number;
-  completions: number;
-}
-
-interface GameFilters {
-  timeRange: string;
-  gameType: string;
-  difficulty: string;
-  studentGroup: string;
-}
-
-/**
- * Fetch game analytics from API
- * @param filters - Filter criteria
- * @returns Promise with game analytics data
- */
-const fetchGameAnalytics = async (filters: GameFilters): Promise<GameAnalytics> => {
-  const params = new URLSearchParams();
-  
-  if (filters.timeRange && filters.timeRange !== 'all') params.append('time_range', filters.timeRange);
-  if (filters.gameType && filters.gameType !== 'all') params.append('game_type', filters.gameType);
-  if (filters.difficulty && filters.difficulty !== 'all') params.append('difficulty', filters.difficulty);
-  if (filters.studentGroup && filters.studentGroup !== 'all') params.append('student_group', filters.studentGroup);
-  
-  const response = await fetch(`/api/teacher/game-analytics?${params.toString()}`, {
-    headers: {
-      'Authorization': `Bearer ${localStorage.getItem('auth_token')}`,
-      'Content-Type': 'application/json',
-    },
-  });
-  
-  if (!response.ok) {
-    throw new Error('Failed to fetch game analytics');
-  }
-  
-  const data = await response.json();
-  return data.analytics;
+  return {
+    totalSessions: Number(payload.total_sessions ?? 0),
+    averageSessionDuration: payload.average_session_duration ?? '0 minutes',
+    mostPopularGame: payload.most_popular_game ?? 'N/A',
+    topPerformers: Array.isArray(payload.top_performers) ? payload.top_performers : [],
+    weeklyActivity: Array.isArray(payload.weekly_activity) ? payload.weekly_activity : [],
+    gameTypes: Array.isArray(payload.game_types)
+      ? payload.game_types.map((type) => ({
+          name: type.name,
+          sessions: Number(type.sessions ?? 0),
+          avgScore: Number(type.avg_score ?? 0),
+        }))
+      : [],
+  };
 };
 
-/**
- * Get difficulty badge styling
- * @param difficulty - Game difficulty level
- * @returns CSS classes for badge
- */
-function getDifficultyBadge(difficulty: string) {
-  switch (difficulty) {
-    case 'easy':
-      return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
-    case 'medium':
-      return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
-    case 'hard':
-      return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
-    default:
-      return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200';
-  }
-}
-
-/**
- * Format time duration
- * @param minutes - Time in minutes
- * @returns Formatted time string
- */
-function formatTime(minutes: number): string {
-  if (minutes < 60) {
-    return `${Math.round(minutes)}m`;
-  }
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = Math.round(minutes % 60);
-  return `${hours}h ${remainingMinutes}m`;
-}
-
-/**
- * Overview metrics component
- * @param overview - Overview data
- */
-interface OverviewMetricsProps {
-  overview: GameOverview;
-}
-
-function OverviewMetrics({ overview }: OverviewMetricsProps) {
-  const t = useTranslations('teacher.gameAnalytics');
-  
-  const metrics = [
-    {
-      label: t('metrics.totalSessions', { defaultValue: 'Total Sessions' }),
-      value: overview.totalSessions.toLocaleString(),
-      icon: Gamepad2,
-      color: 'text-blue-600 dark:text-blue-400',
-      bgColor: 'bg-blue-50 dark:bg-blue-900/20',
-    },
-    {
-      label: t('metrics.averageScore', { defaultValue: 'Average Score' }),
-      value: `${Math.round(overview.averageScore)}%`,
-      icon: Target,
-      color: 'text-emerald-600 dark:text-emerald-400',
-      bgColor: 'bg-emerald-50 dark:bg-emerald-900/20',
-    },
-    {
-      label: t('metrics.completionRate', { defaultValue: 'Completion Rate' }),
-      value: `${Math.round(overview.completionRate)}%`,
-      icon: Trophy,
-      color: 'text-yellow-600 dark:text-yellow-400',
-      bgColor: 'bg-yellow-50 dark:bg-yellow-900/20',
-    },
-    {
-      label: t('metrics.activeStudents', { defaultValue: 'Active Students' }),
-      value: overview.activeStudents.toString(),
-      icon: Users,
-      color: 'text-purple-600 dark:text-purple-400',
-      bgColor: 'bg-purple-50 dark:bg-purple-900/20',
-    },
-    {
-      label: t('metrics.totalPlayTime', { defaultValue: 'Total Play Time' }),
-      value: formatTime(overview.totalPlayTime),
-      icon: Clock,
-      color: 'text-indigo-600 dark:text-indigo-400',
-      bgColor: 'bg-indigo-50 dark:bg-indigo-900/20',
-    },
-    {
-      label: t('metrics.highestScore', { defaultValue: 'Highest Score' }),
-      value: `${overview.highestScore}%`,
-      icon: Star,
-      color: 'text-orange-600 dark:text-orange-400',
-      bgColor: 'bg-orange-50 dark:bg-orange-900/20',
-    },
-  ];
-  
+function GameAnalyticsLoading() {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {metrics.map((metric, index) => {
-        const Icon = metric.icon;
-        return (
-          <motion.div
-            key={metric.label}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: index * 0.1 }}
-          >
-            <Card className="bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm border-gray-200 dark:border-gray-700 hover:shadow-lg transition-all duration-300">
-              <CardContent className="p-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">
-                      {metric.label}
-                    </p>
-                    <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                      {metric.value}
-                    </p>
-                  </div>
-                  <div className={`p-3 rounded-lg ${metric.bgColor}`}>
-                    <Icon className={`h-6 w-6 ${metric.color}`} />
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </motion.div>
-        );
-      })}
-    </div>
-  );
-}
-
-/**
- * Top performers leaderboard component
- * @param performers - Top performer data
- */
-interface TopPerformersProps {
-  performers: TopPerformer[];
-}
-
-function TopPerformers({ performers }: TopPerformersProps) {
-  const t = useTranslations('teacher.gameAnalytics');
-  
-  return (
-    <Card className="bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm border-gray-200 dark:border-gray-700">
-      <CardHeader>
-        <CardTitle className="flex items-center text-gray-900 dark:text-white">
-          <Trophy className="h-5 w-5 mr-2 text-yellow-500" />
-          {t('topPerformers.title', { defaultValue: 'Top Performers' })}
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <ScrollArea className="h-80">
-          <div className="space-y-3">
-            {performers.map((performer, index) => (
-              <motion.div
-                key={performer.id}
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: index * 0.1 }}
-                className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-              >
-                <div className="flex items-center space-x-3">
-                  <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gradient-to-r from-yellow-400 to-orange-500 text-white font-bold text-sm">
-                    {performer.rank}
-                  </div>
-                  
-                  <div className="flex-1">
-                    <p className="font-medium text-gray-900 dark:text-white">
-                      {performer.name}
-                    </p>
-                    <div className="flex items-center space-x-4 text-sm text-gray-600 dark:text-gray-400">
-                      <span>{performer.gamesPlayed} games</span>
-                      <span>Avg: {Math.round(performer.averageScore)}%</span>
-                    </div>
-                  </div>
-                </div>
-                
-                <div className="text-right">
-                  <div className="text-lg font-bold text-emerald-600 dark:text-emerald-400">
-                    {performer.score}%
-                  </div>
-                  <div className="flex items-center space-x-1">
-                    {performer.badges.slice(0, 3).map((badge, badgeIndex) => (
-                      <Award key={badgeIndex} className="h-4 w-4 text-yellow-500" />
-                    ))}
-                    {performer.badges.length > 3 && (
-                      <span className="text-xs text-gray-500">+{performer.badges.length - 3}</span>
-                    )}
-                  </div>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </ScrollArea>
-      </CardContent>
-    </Card>
-  );
-}
-
-/**
- * Game statistics component
- * @param gameStats - Game statistics data
- */
-interface GameStatsProps {
-  gameStats: GameStats[];
-}
-
-function GameStatsGrid({ gameStats }: GameStatsProps) {
-  const t = useTranslations('teacher.gameAnalytics');
-  
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-      {gameStats.map((game, index) => (
-        <motion.div
-          key={game.gameType}
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: index * 0.1 }}
-        >
-          <Card className="bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm border-gray-200 dark:border-gray-700 hover:shadow-lg transition-all duration-300">
-            <CardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-lg font-semibold text-gray-900 dark:text-white capitalize">
-                  {game.gameType.replace('_', ' ')}
-                </CardTitle>
-                <Badge className={getDifficultyBadge(game.difficulty)}>
-                  {t(`difficulty.${game.difficulty}`, { defaultValue: game.difficulty })}
-                </Badge>
-              </div>
-            </CardHeader>
-            
-            <CardContent>
-              <div className="grid grid-cols-2 gap-4">
-                <div className="text-center">
-                  <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
-                    {game.sessionsPlayed}
-                  </div>
-                  <div className="text-xs text-gray-600 dark:text-gray-400">
-                    {t('gameStats.sessions', { defaultValue: 'Sessions' })}
-                  </div>
-                </div>
-                
-                <div className="text-center">
-                  <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">
-                    {Math.round(game.averageScore)}%
-                  </div>
-                  <div className="text-xs text-gray-600 dark:text-gray-400">
-                    {t('gameStats.avgScore', { defaultValue: 'Avg Score' })}
-                  </div>
-                </div>
-                
-                <div className="text-center">
-                  <div className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">
-                    {Math.round(game.completionRate)}%
-                  </div>
-                  <div className="text-xs text-gray-600 dark:text-gray-400">
-                    {t('gameStats.completion', { defaultValue: 'Completion' })}
-                  </div>
-                </div>
-                
-                <div className="text-center">
-                  <div className="text-2xl font-bold text-purple-600 dark:text-purple-400">
-                    {formatTime(game.averageTime)}
-                  </div>
-                  <div className="text-xs text-gray-600 dark:text-gray-400">
-                    {t('gameStats.avgTime', { defaultValue: 'Avg Time' })}
-                  </div>
-                </div>
-              </div>
-              
-              {/* Popularity Bar */}
-              <div className="mt-4">
-                <div className="flex items-center justify-between text-sm mb-1">
-                  <span className="text-gray-600 dark:text-gray-400">
-                    {t('gameStats.popularity', { defaultValue: 'Popularity' })}
-                  </span>
-                  <span className="text-gray-900 dark:text-white font-medium">
-                    {Math.round(game.popularity)}%
-                  </span>
-                </div>
-                <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-                  <motion.div
-                    className="bg-gradient-to-r from-emerald-500 to-blue-500 h-2 rounded-full"
-                    initial={{ width: 0 }}
-                    animate={{ width: `${game.popularity}%` }}
-                    transition={{ duration: 1, delay: index * 0.2 }}
-                  />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </motion.div>
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <Card key={index} className="bg-white/70 dark:bg-gray-800/70 border-gray-200 dark:border-gray-700">
+          <CardContent className="p-6 space-y-4">
+            <Skeleton className="h-6 w-1/2" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+          </CardContent>
+        </Card>
       ))}
     </div>
   );
 }
 
-/**
- * Engagement metrics component
- * @param metrics - Engagement metrics data
- */
-interface EngagementMetricsProps {
-  metrics: EngagementMetrics;
-}
-
-function EngagementMetrics({ metrics }: EngagementMetricsProps) {
-  const t = useTranslations('teacher.gameAnalytics');
-  
+function WeeklyActivityList({ activity }: { activity: { day: string; sessions: number }[] }) {
   return (
-    <Card className="bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm border-gray-200 dark:border-gray-700">
-      <CardHeader>
-        <CardTitle className="flex items-center text-gray-900 dark:text-white">
-          <Activity className="h-5 w-5 mr-2 text-emerald-500" />
-          {t('engagement.title', { defaultValue: 'Engagement Metrics' })}
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-          <div className="text-center p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-            <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
-              {metrics.dailyActive}
-            </div>
-            <div className="text-sm text-blue-700 dark:text-blue-300">
-              {t('engagement.daily', { defaultValue: 'Daily Active' })}
-            </div>
-          </div>
-          
-          <div className="text-center p-4 bg-emerald-50 dark:bg-emerald-900/20 rounded-lg">
-            <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">
-              {metrics.weeklyActive}
-            </div>
-            <div className="text-sm text-emerald-700 dark:text-emerald-300">
-              {t('engagement.weekly', { defaultValue: 'Weekly Active' })}
-            </div>
-          </div>
-          
-          <div className="text-center p-4 bg-purple-50 dark:bg-purple-900/20 rounded-lg">
-            <div className="text-2xl font-bold text-purple-600 dark:text-purple-400">
-              {metrics.monthlyActive}
-            </div>
-            <div className="text-sm text-purple-700 dark:text-purple-300">
-              {t('engagement.monthly', { defaultValue: 'Monthly Active' })}
-            </div>
-          </div>
-          
-          <div className="text-center p-4 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg">
-            <div className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">
-              {Math.round(metrics.retentionRate)}%
-            </div>
-            <div className="text-sm text-yellow-700 dark:text-yellow-300">
-              {t('engagement.retention', { defaultValue: 'Retention' })}
-            </div>
-          </div>
+    <div className="space-y-2">
+      {activity.map((entry) => (
+        <div key={entry.day} className="flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
+          <span>{entry.day}</span>
+          <Badge variant="outline" className="bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-200">
+            {entry.sessions} sessions
+          </Badge>
         </div>
-        
-        {/* Peak Hours Chart */}
-        <div>
-          <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-            {t('engagement.peakHours', { defaultValue: 'Peak Activity Hours' })}
-          </h4>
-          <div className="flex items-end space-x-1 h-32">
-            {metrics.peakHours.map((hour, index) => {
-              const maxSessions = Math.max(...metrics.peakHours.map(h => h.sessions));
-              const height = (hour.sessions / maxSessions) * 100;
-              
-              return (
-                <div key={hour.hour} className="flex-1 flex flex-col items-center">
-                  <motion.div
-                    className="w-full bg-gradient-to-t from-emerald-500 to-blue-500 rounded-t"
-                    initial={{ height: 0 }}
-                    animate={{ height: `${height}%` }}
-                    transition={{ duration: 1, delay: index * 0.05 }}
-                  />
-                  <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
-                    {hour.hour}:00
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-/**
- * Loading skeleton for game analytics
- */
-function GameAnalyticsLoading() {
-  return (
-    <div className="space-y-6">
-      {/* Overview Metrics Skeleton */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {Array.from({ length: 6 }).map((_, index) => (
-          <Card key={index} className="bg-white/70 dark:bg-gray-800/70">
-            <CardContent className="p-4">
-              <div className="flex items-center justify-between">
-                <div className="flex-1">
-                  <Skeleton className="h-4 w-24 mb-2" />
-                  <Skeleton className="h-8 w-16" />
-                </div>
-                <Skeleton className="h-12 w-12 rounded-lg" />
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-      
-      {/* Content Skeleton */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <Card className="bg-white/70 dark:bg-gray-800/70">
-          <CardHeader>
-            <Skeleton className="h-6 w-32" />
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {Array.from({ length: 5 }).map((_, index) => (
-                <div key={index} className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-800">
-                  <div className="flex items-center space-x-3">
-                    <Skeleton className="h-8 w-8 rounded-full" />
-                    <div>
-                      <Skeleton className="h-4 w-24 mb-1" />
-                      <Skeleton className="h-3 w-32" />
-                    </div>
-                  </div>
-                  <Skeleton className="h-6 w-12" />
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-        
-        <Card className="bg-white/70 dark:bg-gray-800/70">
-          <CardHeader>
-            <Skeleton className="h-6 w-40" />
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 gap-4 mb-6">
-              {Array.from({ length: 4 }).map((_, index) => (
-                <div key={index} className="text-center p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                  <Skeleton className="h-8 w-12 mx-auto mb-2" />
-                  <Skeleton className="h-3 w-16 mx-auto" />
-                </div>
-              ))}
-            </div>
-            <Skeleton className="h-32 w-full" />
-          </CardContent>
-        </Card>
-      </div>
+      ))}
     </div>
   );
 }
 
-/**
- * Empty state component
- */
-function EmptyGameAnalytics() {
-  const t = useTranslations('teacher.gameAnalytics');
-  
+function GameTypeList({ gameTypes }: { gameTypes: { name: string; sessions: number; avgScore: number }[] }) {
   return (
-    <div className="text-center py-12">
-      <div className="text-gray-400 dark:text-gray-600 mb-4">
-        <Gamepad2 className="h-16 w-16 mx-auto" />
-      </div>
-      <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
-        {t('empty.title', { defaultValue: 'No Game Data Yet' })}
-      </h3>
-      <p className="text-gray-600 dark:text-gray-400 max-w-md mx-auto">
-        {t('empty.description', { 
-          defaultValue: 'Game analytics will appear here once students start playing educational games.' 
-        })}
-      </p>
+    <div className="space-y-3">
+      {gameTypes.map((game) => (
+        <div key={game.name} className="p-3 rounded-lg bg-gray-50 dark:bg-gray-800/60 flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-gray-900 dark:text-white">{game.name}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">{game.sessions} sessions</p>
+          </div>
+          <Badge className="bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200">
+            {Math.round(game.avgScore)}%
+          </Badge>
+        </div>
+      ))}
     </div>
   );
 }
 
-/**
- * Main Game Analytics Section Component
- * Displays game performance metrics and student engagement data
- */
 export default function GameAnalyticsSection() {
   const t = useTranslations('teacher.gameAnalytics');
-  
-  const [filters, setFilters] = useState<GameFilters>({
-    timeRange: 'week',
-    gameType: 'all',
-    difficulty: 'all',
-    studentGroup: 'all',
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['teacher-game-analytics'],
+    queryFn: fetchGameAnalytics,
+    staleTime: 5 * 60 * 1000,
   });
 
-  const { data: analytics, isLoading, error, refetch } = useQuery({
-    queryKey: ['teacher-game-analytics', filters],
-    queryFn: () => fetchGameAnalytics(filters),
-    refetchInterval: 5 * 60 * 1000, // Refetch every 5 minutes
-  });
+  const containerVariants = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        staggerChildren: 0.1,
+        delayChildren: 0.1,
+      },
+    },
+  };
 
-  const updateFilter = (key: keyof GameFilters, value: string) => {
-    setFilters(prev => ({ ...prev, [key]: value }));
+  const itemVariants = {
+    hidden: { opacity: 0, y: 20 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: { duration: 0.4, ease: 'easeOut' },
+    },
   };
 
   if (isLoading) {
     return <GameAnalyticsLoading />;
   }
 
-  if (error) {
+  if (error || !data) {
     return (
       <Card className="bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800">
         <CardContent className="p-6 text-center">
           <div className="text-red-600 dark:text-red-400 mb-2">
-            <Gamepad2 className="h-8 w-8 mx-auto" />
+            <BarChart3 className="h-8 w-8 mx-auto" />
           </div>
           <h3 className="text-lg font-semibold text-red-800 dark:text-red-200 mb-2">
-            {t('error.title', { defaultValue: 'Failed to Load Game Analytics' })}
+            {t('error.title', { defaultValue: 'Unable to load game analytics' })}
           </h3>
-          <p className="text-red-600 dark:text-red-400 text-sm mb-4">
-            {(error as Error).message}
-          </p>
-          <Button 
-            onClick={() => refetch()} 
-            variant="outline" 
-            size="sm"
-            className="border-red-300 text-red-700 hover:bg-red-50"
-          >
-            <RefreshCw className="h-4 w-4 mr-2" />
-            {t('error.retry', { defaultValue: 'Try Again' })}
-          </Button>
+          <p className="text-sm text-red-600 dark:text-red-400">{(error as Error)?.message ?? 'Unknown error'}</p>
         </CardContent>
       </Card>
     );
   }
 
-  if (!analytics || analytics.overview.totalSessions === 0) {
-    return <EmptyGameAnalytics />;
-  }
-
   return (
-    <div className="space-y-6">
-      {/* Header & Filters */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-            {t('title', { defaultValue: 'Game Analytics' })}
-          </h3>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            {t('subtitle', { 
-              defaultValue: `${analytics.overview.totalSessions} total game sessions` 
-            })}
-          </p>
-        </div>
-        
-        <div className="flex items-center space-x-2">
-          <Button 
-            onClick={() => refetch()} 
-            variant="outline" 
-            size="sm"
-          >
-            <RefreshCw className="h-4 w-4 mr-2" />
-            {t('refresh', { defaultValue: 'Refresh' })}
-          </Button>
-          
-          <Button variant="outline" size="sm">
-            <Download className="h-4 w-4 mr-2" />
-            {t('export', { defaultValue: 'Export' })}
-          </Button>
-        </div>
-      </div>
-      
-      {/* Filter Controls */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Select value={filters.timeRange} onValueChange={(value) => updateFilter('timeRange', value)}>
-          <SelectTrigger>
-            <SelectValue placeholder={t('filters.timeRange', { defaultValue: 'Time Range' })} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="day">{t('timeRange.day', { defaultValue: 'Today' })}</SelectItem>
-            <SelectItem value="week">{t('timeRange.week', { defaultValue: 'This Week' })}</SelectItem>
-            <SelectItem value="month">{t('timeRange.month', { defaultValue: 'This Month' })}</SelectItem>
-            <SelectItem value="quarter">{t('timeRange.quarter', { defaultValue: 'This Quarter' })}</SelectItem>
-          </SelectContent>
-        </Select>
-        
-        <Select value={filters.gameType} onValueChange={(value) => updateFilter('gameType', value)}>
-          <SelectTrigger>
-            <SelectValue placeholder={t('filters.gameType', { defaultValue: 'Game Type' })} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">{t('gameType.all', { defaultValue: 'All Games' })}</SelectItem>
-            <SelectItem value="memory">{t('gameType.memory', { defaultValue: 'Memory Games' })}</SelectItem>
-            <SelectItem value="recitation">{t('gameType.recitation', { defaultValue: 'Recitation Games' })}</SelectItem>
-            <SelectItem value="quiz">{t('gameType.quiz', { defaultValue: 'Quiz Games' })}</SelectItem>
-          </SelectContent>
-        </Select>
-        
-        <Select value={filters.difficulty} onValueChange={(value) => updateFilter('difficulty', value)}>
-          <SelectTrigger>
-            <SelectValue placeholder={t('filters.difficulty', { defaultValue: 'Difficulty' })} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">{t('difficulty.all', { defaultValue: 'All Levels' })}</SelectItem>
-            <SelectItem value="easy">{t('difficulty.easy', { defaultValue: 'Easy' })}</SelectItem>
-            <SelectItem value="medium">{t('difficulty.medium', { defaultValue: 'Medium' })}</SelectItem>
-            <SelectItem value="hard">{t('difficulty.hard', { defaultValue: 'Hard' })}</SelectItem>
-          </SelectContent>
-        </Select>
-        
-        <Select value={filters.studentGroup} onValueChange={(value) => updateFilter('studentGroup', value)}>
-          <SelectTrigger>
-            <SelectValue placeholder={t('filters.studentGroup', { defaultValue: 'Student Group' })} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">{t('studentGroup.all', { defaultValue: 'All Students' })}</SelectItem>
-            {/* Add dynamic class options here */}
-          </SelectContent>
-        </Select>
-      </div>
+    <motion.div variants={containerVariants} initial="hidden" animate="visible" className="space-y-6">
+      <motion.div variants={itemVariants} className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Card className="bg-white/70 dark:bg-gray-800/70 border-gray-200 dark:border-gray-700">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center text-sm font-medium text-gray-900 dark:text-white">
+              <Gamepad2 className="h-4 w-4 mr-2 text-emerald-600" />
+              {t('summary.sessions', { defaultValue: 'Total Sessions' })}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">{data.totalSessions.toLocaleString()}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {t('summary.sessionsHelper', { defaultValue: 'Sessions recorded this month' })}
+            </p>
+          </CardContent>
+        </Card>
 
-      {/* Overview Metrics */}
-      <OverviewMetrics overview={analytics.overview} />
+        <Card className="bg-white/70 dark:bg-gray-800/70 border-gray-200 dark:border-gray-700">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center text-sm font-medium text-gray-900 dark:text-white">
+              <Target className="h-4 w-4 mr-2 text-blue-600" />
+              {t('summary.duration', { defaultValue: 'Average Session Duration' })}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">{data.averageSessionDuration}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {t('summary.durationHelper', { defaultValue: 'Across all games' })}
+            </p>
+          </CardContent>
+        </Card>
 
-      {/* Main Content Grid */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Top Performers */}
-        <TopPerformers performers={analytics.topPerformers} />
-        
-        {/* Engagement Metrics */}
-        <EngagementMetrics metrics={analytics.engagementMetrics} />
-      </div>
+        <Card className="bg-white/70 dark:bg-gray-800/70 border-gray-200 dark:border-gray-700">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center text-sm font-medium text-gray-900 dark:text-white">
+              <Trophy className="h-4 w-4 mr-2 text-amber-600" />
+              {t('summary.popularGame', { defaultValue: 'Most Popular Game' })}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <p className="text-lg font-semibold text-gray-900 dark:text-white">{data.mostPopularGame}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {t('summary.popularGameHelper', { defaultValue: 'Highest engagement this week' })}
+            </p>
+          </CardContent>
+        </Card>
+      </motion.div>
 
-      {/* Game Statistics */}
-      <div>
-        <h4 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-          {t('gameStats.title', { defaultValue: 'Game Performance' })}
-        </h4>
-        <GameStatsGrid gameStats={analytics.gameStats} />
-      </div>
-    </div>
+      <motion.div variants={itemVariants} className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card className="bg-white/70 dark:bg-gray-800/70 border-gray-200 dark:border-gray-700">
+          <CardHeader>
+            <CardTitle className="text-sm font-semibold text-gray-900 dark:text-white">
+              {t('topPerformers.title', { defaultValue: 'Top Performers' })}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {data.topPerformers.map((performer) => (
+              <div
+                key={performer.name}
+                className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-800/60"
+              >
+                <div>
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">{performer.name}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">{performer.level}</p>
+                </div>
+                <Badge className="bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-200">
+                  {performer.score}
+                </Badge>
+              </div>
+            ))}
+            {data.topPerformers.length === 0 && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {t('topPerformers.empty', { defaultValue: 'No game data available yet.' })}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="bg-white/70 dark:bg-gray-800/70 border-gray-200 dark:border-gray-700">
+          <CardHeader>
+            <CardTitle className="text-sm font-semibold text-gray-900 dark:text-white">
+              {t('weeklyActivity.title', { defaultValue: 'Weekly Activity' })}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <WeeklyActivityList activity={data.weeklyActivity} />
+          </CardContent>
+        </Card>
+      </motion.div>
+
+      <motion.div variants={itemVariants}>
+        <Card className="bg-white/70 dark:bg-gray-800/70 border-gray-200 dark:border-gray-700">
+          <CardHeader>
+            <CardTitle className="flex items-center text-sm font-semibold text-gray-900 dark:text-white">
+              <Users className="h-4 w-4 mr-2 text-purple-600" />
+              {t('gameTypes.title', { defaultValue: 'Game Types Overview' })}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <GameTypeList gameTypes={data.gameTypes} />
+          </CardContent>
+        </Card>
+      </motion.div>
+    </motion.div>
   );
 }

--- a/apps/web/src/components/teacher/MemorizationOversightSection.tsx
+++ b/apps/web/src/components/teacher/MemorizationOversightSection.tsx
@@ -1,17 +1,12 @@
 /* AlFawz Qur'an Institute — generated with TRAE */
 /* Author: Auto-scaffold (review required) */
 
-"use client";
+'use client';
 
 import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -39,8 +34,8 @@ import {
   AlertCircle,
   Calendar,
 } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
-import { apiClient } from '@/lib/api';
+import { useTranslations } from 'next-intl';
+import { api } from '@/lib/api';
 
 interface MemorizationProgress {
   id: number;
@@ -73,8 +68,15 @@ interface StudentMemorizationStats {
  */
 const fetchMemorizationProgress = async (classId?: string): Promise<MemorizationProgress[]> => {
   const params = classId ? `?class_id=${classId}` : '';
-  const response = await apiClient.get(`/teacher/memorization-progress${params}`);
-  return response.data;
+  const response = await api.get(`/teacher/memorization-progress${params}`);
+  const payload = (response?.data ?? response) as unknown;
+  if (Array.isArray(payload)) {
+    return payload as MemorizationProgress[];
+  }
+  if (Array.isArray((payload as { data?: MemorizationProgress[] }).data)) {
+    return (payload as { data: MemorizationProgress[] }).data;
+  }
+  return [];
 };
 
 /**
@@ -84,8 +86,15 @@ const fetchMemorizationProgress = async (classId?: string): Promise<Memorization
  */
 const fetchStudentStats = async (classId?: string): Promise<StudentMemorizationStats[]> => {
   const params = classId ? `?class_id=${classId}` : '';
-  const response = await apiClient.get(`/teacher/memorization-stats${params}`);
-  return response.data;
+  const response = await api.get(`/teacher/memorization-stats${params}`);
+  const payload = (response?.data ?? response) as unknown;
+  if (Array.isArray(payload)) {
+    return payload as StudentMemorizationStats[];
+  }
+  if (Array.isArray((payload as { data?: StudentMemorizationStats[] }).data)) {
+    return (payload as { data: StudentMemorizationStats[] }).data;
+  }
+  return [];
 };
 
 /**
@@ -93,7 +102,7 @@ const fetchStudentStats = async (classId?: string): Promise<StudentMemorizationS
  * Displays student memorization progress, due reviews, and performance metrics
  */
 export default function MemorizationOversightSection() {
-  const { t } = useTranslation();
+  const t = useTranslations('teacher.memorization');
   const [selectedClass, setSelectedClass] = useState<string>('all');
   const [viewMode, setViewMode] = useState<'progress' | 'stats'>('progress');
 
@@ -132,10 +141,12 @@ export default function MemorizationOversightSection() {
     const now = new Date();
     const diffHours = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60));
     
-    if (diffHours < 1) return t('memorization.justNow', { defaultValue: 'Just now' });
-    if (diffHours < 24) return t('memorization.hoursAgo', { defaultValue: '{{hours}}h ago', hours: diffHours });
+    if (diffHours < 1) return t('justNow', { defaultValue: 'Just now' });
+    if (diffHours < 24) {
+      return t('hoursAgo', { defaultValue: '{{hours}}h ago', hours: diffHours });
+    }
     const diffDays = Math.floor(diffHours / 24);
-    return t('memorization.daysAgo', { defaultValue: '{{days}}d ago', days: diffDays });
+    return t('daysAgo', { defaultValue: '{{days}}d ago', days: diffDays });
   };
 
   if (progressLoading || statsLoading) {


### PR DESCRIPTION
## Summary
- expose a dedicated teacher submission grading endpoint and register it in the API routes to keep grading within the teacher panel
- replace the teacher dashboard analytics, classes, notifications, memorization oversight, submissions, and game analytics React components with implementations that consume the Laravel API client and map backend payloads
- streamline UI data handling for teacher panels so counts, summaries, and actions reflect live backend data

## Testing
- npm run lint *(fails: existing repository lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cb38e5db1c832793dbf26606d5c477