### PR TITLE
Fix user status evaluation logic

### DIFF
--- a/apps/api/app/Http/Controllers/Admin/AdminUserController.php
+++ b/apps/api/app/Http/Controllers/Admin/AdminUserController.php
@@ -339,23 +339,16 @@ class AdminUserController extends Controller
             return 'pending';
         }
 
-        if ($user->status === 'active') {
-            if ($user->last_login_at && $user->last_login_at < now()->subDays(30)) {
-                return 'inactive';
-            }
-
-            return 'active';
-        }
-
+        // At this point, status is considered active
         if (!$user->last_login_at) {
             return 'new';
         }
 
-        if ($user->last_login_at >= now()->subDays(30)) {
-            return 'active';
+        if ($user->last_login_at < now()->subDays(30)) {
+            return 'inactive';
         }
 
-        return 'inactive';
+        return 'active';
     }
     
     /**


### PR DESCRIPTION
## Summary
- simplify admin user status evaluation by assuming active state after handling suspended and pending
- mark users without a login as new and classify stale active logins as inactive

## Testing
- php -l apps/api/app/Models/User.php
- php -l apps/api/app/Http/Controllers/Admin/AdminUserController.php

------
https://chatgpt.com/codex/tasks/task_e_68cb48749b848327b8431bead6e00101