### PR TITLE
Harden auth flows and add student class access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ composer.phar
 # PHPUnit
 .phpunit.result.cache
 phpunit.xml
+!apps/api/phpunit.xml
 coverage.xml
 
 # PHP CS Fixer

--- a/apps/api/app/DataTransferObjects/Auth/RegisterRequestData.php
+++ b/apps/api/app/DataTransferObjects/Auth/RegisterRequestData.php
@@ -8,18 +8,18 @@ class RegisterRequestData
         public string $name,
         public string $email,
         public string $password,
-        public string $role,
+        public string $role = 'student',
         public ?string $phone = null,
         public int $level = 1,
     ) {}
 
-    public static function fromArray(array $validated): self
+    public static function fromArray(array $validated, string $defaultRole = 'student'): self
     {
         return new self(
             name: $validated['name'],
             email: $validated['email'],
             password: $validated['password'],
-            role: $validated['role'],
+            role: $defaultRole,
             phone: $validated['phone'] ?? null,
             level: (int) ($validated['level'] ?? 1),
         );

--- a/apps/api/app/Models/ClassModel.php
+++ b/apps/api/app/Models/ClassModel.php
@@ -54,7 +54,7 @@ class ClassModel extends Model
      */
     public function members(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, 'class_members')
+        return $this->belongsToMany(User::class, 'class_members', 'class_id', 'user_id')
                     ->withPivot('role_in_class')
                     ->withTimestamps();
     }

--- a/apps/api/app/Notifications/VerifyEmailNotification.php
+++ b/apps/api/app/Notifications/VerifyEmailNotification.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class VerifyEmailNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Get the notification's delivery channels.
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Build the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $appName = config('app.name', 'AlFawz Qur\'an Institute');
+        $frontendBase = rtrim((string) config('app.frontend_url', config('app.url')), '/');
+        $verificationUrl = $frontendBase ? $frontendBase . '/verify-email' : null;
+
+        $mail = (new MailMessage())
+            ->subject("Verify your email for {$appName}")
+            ->greeting("As-salaamu alaykum {$notifiable->name}!")
+            ->line("Thank you for joining {$appName}.")
+            ->line('To complete your registration, please verify your email address from within your account.');
+
+        if ($verificationUrl) {
+            $mail->action('Verify Email', $verificationUrl);
+        }
+
+        return $mail->line('You can also sign in to the app and choose "Verify Email" from your profile.');
+    }
+}

--- a/apps/api/phpunit.xml
+++ b/apps/api/phpunit.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory="storage/framework/cache/phpunit"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage cacheDirectory="storage/framework/cache/phpunit">
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+    </coverage>
+
+    <php>
+        <server name="APP_ENV" value="testing"/>
+        <server name="BCRYPT_ROUNDS" value="4"/>
+        <server name="CACHE_DRIVER" value="array"/>
+        <server name="DB_CONNECTION" value="sqlite"/>
+        <server name="DB_DATABASE" value=":memory:"/>
+        <server name="MAIL_MAILER" value="array"/>
+        <server name="QUEUE_CONNECTION" value="sync"/>
+        <server name="SESSION_DRIVER" value="array"/>
+        <server name="SANCTUM_STATEFUL_DOMAINS" value="localhost"/>
+    </php>
+</phpunit>

--- a/apps/api/tests/Feature/AuthEndpointsTest.php
+++ b/apps/api/tests/Feature/AuthEndpointsTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Notifications\VerifyEmailNotification;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class AuthEndpointsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        foreach (['student', 'teacher', 'admin'] as $role) {
+            Role::findOrCreate($role, 'web');
+        }
+    }
+
+    public function test_registration_assigns_student_role_by_default(): void
+    {
+        $response = $this->postJson('/api/auth/register', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'role' => 'admin',
+        ]);
+
+        $response->assertCreated();
+
+        $user = User::where('email', 'test@example.com')->firstOrFail();
+
+        $this->assertTrue($user->hasRole('student'));
+        $this->assertFalse($user->hasRole('admin'));
+
+        $response->assertJsonPath('data.roles', ['student']);
+    }
+
+    public function test_forgot_password_sends_reset_notification(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'reset@example.com']);
+
+        $response = $this->postJson('/api/auth/forgot-password', [
+            'email' => $user->email,
+        ]);
+
+        $response->assertOk();
+
+        Notification::assertSentTo($user, ResetPassword::class);
+    }
+
+    public function test_reset_password_updates_password_and_revokes_tokens(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'change@example.com',
+            'password' => Hash::make('OldPassword123!'),
+        ]);
+
+        $user->createToken('auth-token');
+
+        $token = Password::broker()->createToken($user);
+
+        $response = $this->postJson('/api/auth/reset-password', [
+            'email' => $user->email,
+            'token' => $token,
+            'password' => 'NewPassword123!',
+            'password_confirmation' => 'NewPassword123!',
+        ]);
+
+        $response->assertOk();
+
+        $this->assertTrue(Hash::check('NewPassword123!', $user->fresh()->password));
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'tokenable_id' => $user->id,
+        ]);
+    }
+
+    public function test_user_endpoint_returns_authenticated_user_details(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('student');
+
+        $token = $user->createToken('auth-token');
+
+        $response = $this->withToken($token->plainTextToken)->getJson('/api/auth/user');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.user.email', $user->email);
+        $response->assertJsonPath('data.roles.0', 'student');
+    }
+
+    public function test_refresh_endpoint_replaces_current_token(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('student');
+
+        $originalToken = $user->createToken('auth-token');
+        $originalTokenId = $originalToken->accessToken->id;
+
+        $response = $this->withToken($originalToken->plainTextToken)->postJson('/api/auth/refresh');
+
+        $response->assertOk();
+        $newToken = $response->json('data.token');
+
+        $this->assertNotEmpty($newToken);
+        $this->assertDatabaseMissing('personal_access_tokens', ['id' => $originalTokenId]);
+        $this->assertDatabaseHas('personal_access_tokens', ['tokenable_id' => $user->id]);
+    }
+
+    public function test_verify_email_marks_user_as_verified(): void
+    {
+        $user = User::factory()->unverified()->create();
+        $user->assignRole('student');
+
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/auth/email/verify');
+
+        $response->assertOk();
+        $this->assertNotNull($user->fresh()->email_verified_at);
+    }
+
+    public function test_resend_verification_email_dispatches_notification(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->unverified()->create();
+        $user->assignRole('student');
+
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/auth/email/resend');
+
+        $response->assertOk();
+        Notification::assertSentTo($user, VerifyEmailNotification::class);
+    }
+
+    public function test_check_email_verification_returns_status(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('student');
+
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/auth/email/verification-status');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.verified', true);
+    }
+}

--- a/apps/api/tests/Feature/StudentClassAccessTest.php
+++ b/apps/api/tests/Feature/StudentClassAccessTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ClassModel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class StudentClassAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        foreach (['student', 'teacher', 'admin'] as $role) {
+            Role::findOrCreate($role, 'web');
+        }
+    }
+
+    public function test_student_classes_endpoint_returns_enrolled_classes(): void
+    {
+        $teacher = User::factory()->create();
+        $teacher->assignRole('teacher');
+
+        $student = User::factory()->create();
+        $student->assignRole('student');
+
+        $class = ClassModel::create([
+            'teacher_id' => $teacher->id,
+            'title' => 'Morning Recitation',
+            'description' => 'Daily recitation practice',
+            'level' => 1,
+        ]);
+
+        $otherClass = ClassModel::create([
+            'teacher_id' => $teacher->id,
+            'title' => 'Advanced Tajweed',
+            'description' => 'For advanced students only',
+            'level' => 3,
+        ]);
+
+        $class->addMember($student, 'student');
+
+        Sanctum::actingAs($student);
+
+        $response = $this->getJson('/api/student/classes');
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data.classes');
+        $response->assertJsonPath('data.classes.0.id', $class->id);
+        $response->assertJsonPath('data.classes.0.teacher.name', $teacher->name);
+        $response->assertJsonPath('data.classes.0.role_in_class', 'student');
+
+        $response->assertJsonMissing(['id' => $otherClass->id]);
+    }
+
+    public function test_non_student_cannot_access_student_classes(): void
+    {
+        $teacher = User::factory()->create();
+        $teacher->assignRole('teacher');
+
+        Sanctum::actingAs($teacher);
+
+        $response = $this->getJson('/api/student/classes');
+
+        $response->assertForbidden();
+        $response->assertJsonPath('success', false);
+    }
+}


### PR DESCRIPTION
## Summary
- default self-registrations to the student role, wire up the missing auth endpoints, and provide password reset + email verification flows backed by new feature tests
- send a custom email verification notification that does not rely on absent routes and add a committed phpunit configuration for running the Laravel test suite
- expose the student class listing by adding the missing relation/controller method and covering it with feature tests

## Testing
- php artisan test


------
https://chatgpt.com/codex/tasks/task_e_68ccefce82408327b3698026d3e6fa83