### PR TITLE
Fix feedback, payments, and hasanat routes and handlers

### DIFF
--- a/apps/api/app/Http/Controllers/Core/PaymentController.php
+++ b/apps/api/app/Http/Controllers/Core/PaymentController.php
@@ -22,7 +22,7 @@ class PaymentController extends Controller
      * @param Request $request HTTP request with payment data
      * @return \Illuminate\Http\JsonResponse Payment initialization response
      */
-    public function init(Request $request)
+    public function initialize(Request $request)
     {
         $user = $request->user();
         

--- a/apps/api/routes/api.php
+++ b/apps/api/routes/api.php
@@ -410,7 +410,7 @@ Route::middleware('auth:sanctum')->group(function () {
      
      // Resources endpoints
      Route::get('/resources', [ResourceController::class, 'index']);
-     Route::get('/resources/{id}/download', [ResourceController::class, 'download']);
+    Route::get('/resources/{resource}/download', [ResourceController::class, 'download']);
      
      // Notification management
     Route::prefix('notifications')->group(function () {


### PR DESCRIPTION
## Summary
- rename the payment initialization handler so it matches the registered API route
- implement the student feedback listing and align the student resource download route with model binding
- build out missing Hasanat endpoints for history, rewards, redemption, and capabilities while recording awards for history tracking

## Testing
- composer test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68cd15df6800832793daee63c47c0823