### PR TITLE
Fix auth client flow and normalize assignment payloads

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -85,7 +85,7 @@ interface Recommendation {
  * Displays different content based on user role (student/teacher).
  */
 export default function DashboardPage() {
-  const { user, isAuthenticated, isLoading, isStudent, isTeacher } = useAuth();
+  const { user, token, isAuthenticated, isLoading, isStudent, isTeacher } = useAuth();
   const t = useTranslations('dashboard');
   const [stats, setStats] = useState<DashboardStats>({});
   const [isLoadingStats, setIsLoadingStats] = useState(true);
@@ -110,9 +110,7 @@ export default function DashboardPage() {
         setIsLoadingStats(true);
         
         // Set auth token for offline API
-        if (user?.token) {
-          offlineApi.setToken(user.token);
-        }
+        offlineApi.setToken(token ?? null);
         
         if (isStudent) {
           // Fetch student-specific dashboard data with offline support
@@ -156,7 +154,7 @@ export default function DashboardPage() {
     };
 
     fetchStats();
-  }, [isAuthenticated, user, isStudent, isTeacher]);
+  }, [isAuthenticated, user, isStudent, isTeacher, token]);
 
   /**
    * Handle recitation update

--- a/apps/web/src/components/MemorizationSection.tsx
+++ b/apps/web/src/components/MemorizationSection.tsx
@@ -14,6 +14,7 @@ import 'react-circular-progressbar/dist/styles.css';
 import Confetti from 'react-confetti';
 import { useMemorization } from '@/hooks/useMemorization';
 import { useAudio } from '@/hooks/useAudio';
+import { api } from '@/lib/api';
 
 interface MemorizationPlan {
   id: number;
@@ -86,10 +87,9 @@ export default function MemorizationSection() {
    */
   const loadAyah = async (surahId: number, ayahId: number) => {
     try {
-      const response = await fetch(`/api/quran/surahs/${surahId}/ayahs/${ayahId}`);
-      if (response.ok) {
-        const data = await response.json();
-        setCurrentAyah(data);
+      const response = await api.get(`/quran/surahs/${surahId}/ayahs/${ayahId}`);
+      if (response.data) {
+        setCurrentAyah(response.data as AyahData);
         resetModes();
       }
     } catch (error) {

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -23,19 +23,28 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
    */
   useEffect(() => {
     const initAuth = async () => {
+      if (typeof window === 'undefined') {
+        setIsLoading(false);
+        return;
+      }
+
       const storedToken = localStorage.getItem('auth_token');
       if (storedToken) {
         api.setToken(storedToken);
         setToken(storedToken);
-        
+
         try {
           const response = await api.get('/me');
-          setUser(response.data);
+          const profile = response.data?.user ?? response.data ?? response.user;
+          setUser(profile ?? null);
         } catch (error) {
           console.error('Failed to fetch user:', error);
           // Clear invalid token
           api.clearToken();
           setToken(null);
+          if (typeof window !== 'undefined') {
+            localStorage.removeItem('auth_token');
+          }
         }
       }
       setIsLoading(false);
@@ -50,8 +59,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const login = async (credentials: LoginCredentials) => {
     try {
       const response = await api.post('/auth/login', credentials);
-      const { user: userData, token: authToken } = response.data;
-      
+      const payload = response.data ?? {};
+      const userData = payload.user;
+      const authToken = payload.token;
+
+      if (!userData || !authToken) {
+        throw new Error('Invalid authentication response');
+      }
+
       setUser(userData);
       setToken(authToken);
       api.setToken(authToken);
@@ -66,9 +81,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
    */
   const register = async (data: RegisterData) => {
     try {
-      const response = await api.post('/auth/register', data);
-      const { user: userData, token: authToken } = response.data;
-      
+      const payload = {
+        name: data.name,
+        email: data.email,
+        password: data.password,
+        password_confirmation: data.password_confirmation,
+        ...(data.phone ? { phone: data.phone } : {}),
+        ...(data.level ? { level: data.level } : {}),
+      };
+
+      const response = await api.post('/auth/register', payload);
+      const responseData = response.data ?? {};
+      const userData = responseData.user;
+      const authToken = responseData.token;
+
+      if (!userData || !authToken) {
+        throw new Error('Invalid registration response');
+      }
+
       setUser(userData);
       setToken(authToken);
       api.setToken(authToken);

--- a/apps/web/src/types/auth.ts
+++ b/apps/web/src/types/auth.ts
@@ -25,7 +25,8 @@ export interface RegisterData {
   email: string;
   password: string;
   password_confirmation: string;
-  role: 'student' | 'teacher';
+  phone?: string;
+  level?: number;
 }
 
 export interface AuthResponse {


### PR DESCRIPTION
## Summary
- correct the auth context to persist the actual `/me` response shape, sanitize registration payloads, and surface structured API validation errors in the login and registration flows
- harden the shared API client and offline helpers with structured errors, SSR guards, and consistent token usage across the dashboard and memorization widgets
- align Laravel assignment creation and update with the model fillable names so surah, ayah, and difficulty fields are stored correctly

## Testing
- npm run lint *(fails: existing lint violations throughout generated dashboard files)*
- composer test *(fails: vendor dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd67f31b088327b6fd923a5f813c63