### PR TITLE
Guard dashboard UI from server-side window access

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -98,6 +98,7 @@ export default function DashboardPage() {
   const [isReciting, setIsReciting] = useState(false);
   const [fromCache, setFromCache] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+  const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 });
 
   /**
    * Fetch dashboard statistics based on user role with offline support
@@ -155,6 +156,23 @@ export default function DashboardPage() {
 
     fetchStats();
   }, [isAuthenticated, user, isStudent, isTeacher, token]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const updateViewportSize = () => {
+      setViewportSize({ width: window.innerWidth, height: window.innerHeight });
+    };
+
+    updateViewportSize();
+    window.addEventListener('resize', updateViewportSize);
+
+    return () => {
+      window.removeEventListener('resize', updateViewportSize);
+    };
+  }, []);
 
   /**
    * Handle recitation update
@@ -269,10 +287,10 @@ export default function DashboardPage() {
         {isStudent && (
           <div className="space-y-6">
             {/* Confetti Animation */}
-            {showConfetti && (
+            {showConfetti && viewportSize.width > 0 && viewportSize.height > 0 && (
               <Confetti
-                width={window.innerWidth}
-                height={window.innerHeight}
+                width={viewportSize.width}
+                height={viewportSize.height}
                 recycle={false}
                 numberOfPieces={200}
               />

--- a/apps/web/src/components/MemorizationSection.tsx
+++ b/apps/web/src/components/MemorizationSection.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /* AlFawz Qur'an Institute — generated with TRAE */
 /* Author: Auto-scaffold (review required) */
 
@@ -69,10 +71,14 @@ export default function MemorizationSection() {
 
   // Handle window resize for confetti
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
     const handleResize = () => {
       setWindowSize({ width: window.innerWidth, height: window.innerHeight });
     };
-    
+
     handleResize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);

--- a/apps/web/src/components/dashboard/MainDashboard.tsx
+++ b/apps/web/src/components/dashboard/MainDashboard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /* AlFawz Qur'an Institute — generated with TRAE */
 /* Author: Auto-scaffold (review required) */
 
@@ -74,6 +76,24 @@ const MainDashboardContent: React.FC<MainDashboardProps> = ({
   const [activeTab, setActiveTab] = useState('dashboard');
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [notifications, setNotifications] = useState(3);
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleResize = () => {
+      setIsDesktop(window.innerWidth >= 768);
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   // Mock user data if not provided
   const currentUser: User = user || {
@@ -152,7 +172,7 @@ const MainDashboardContent: React.FC<MainDashboardProps> = ({
     <div className={`min-h-screen flex ${className}`} style={{ backgroundColor: theme.colors.milk[50] }}>
       {/* Sidebar */}
       <AnimatePresence>
-        {(sidebarOpen || window.innerWidth >= 768) && (
+        {(sidebarOpen || isDesktop) && (
           <motion.aside
             className="fixed md:relative inset-y-0 left-0 z-50 w-64 flex flex-col"
             style={{ backgroundColor: theme.colors.maroon[900] }}


### PR DESCRIPTION
## Summary
- mark the spiritual dashboard components as client-side modules and add a resize listener so the sidebar no longer touches `window` during the first render
- track the viewport size on the main dashboard page so the confetti animation renders safely without reading from `window`
- guard the memorization section's resize effect against `window` being unavailable during SSR

## Testing
- npx eslint src/components/dashboard/MainDashboard.tsx src/app/dashboard/page.tsx src/components/MemorizationSection.tsx *(fails: pre-existing lint violations throughout the files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd74fe349c832795847a286df3a837