### PR TITLE
Fix build errors caused by missing UI modules

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "@radix-ui/react-slot": "^1.1.2",
         "@tanstack/react-query": "^5.62.9",
         "@tanstack/react-query-devtools": "^5.62.9",
@@ -294,6 +295,15 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,12 +10,13 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "@radix-ui/react-slot": "^1.1.2",
     "@tanstack/react-query": "^5.62.9",
     "@tanstack/react-query-devtools": "^5.62.9",
+    "canvas-confetti": "^1.9.3",
     "class-variance-authority": "^0.7.0",
     "date-fns": "^3.6.0",
-    "canvas-confetti": "^1.9.3",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.474.0",
     "next": "15.5.3",

--- a/apps/web/src/components/LanguageSwitcher.tsx
+++ b/apps/web/src/components/LanguageSwitcher.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { useLocale } from 'next-intl';
-import { useRouter, usePathname } from 'next-intl/client';
+import { useRouter, usePathname } from '@/i18n/navigation';
 import { useSearchParams } from 'next/navigation';
 import { locales, type Locale } from '@/i18n';
 

--- a/apps/web/src/components/LeaderboardPanel.tsx
+++ b/apps/web/src/components/LeaderboardPanel.tsx
@@ -1,7 +1,9 @@
 /* AlFawz Qur'an Institute — generated with TRAE */
 /* Author: Auto-scaffold (review required) */
 
-import React, { useState, useEffect } from 'react';
+'use client';
+
+import React, { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { 
   FaTrophy, 

--- a/apps/web/src/components/teacher/ClassSection.tsx
+++ b/apps/web/src/components/teacher/ClassSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -12,24 +12,6 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
 import {
   Users,
   Plus,
@@ -320,24 +302,23 @@ function ClassForm({ isOpen, onClose, editingClass }: ClassFormProps) {
               />
             </div>
             <div>
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300" htmlFor="class-level">
                 {t('form.level', { defaultValue: 'Level' })}
               </label>
-              <Select
+              <select
+                id="class-level"
                 value={formData.level.toString()}
-                onValueChange={(value) => setFormData((prev) => ({ ...prev, level: parseInt(value, 10) as 1 | 2 | 3 }))}
+                onChange={(event) =>
+                  setFormData((prev) => ({ ...prev, level: parseInt(event.target.value, 10) as 1 | 2 | 3 }))
+                }
+                className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-gray-700 dark:bg-gray-900 dark:text-white"
               >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {([1, 2, 3] as const).map((level) => (
-                    <SelectItem key={level} value={level.toString()}>
-                      {t(LEVEL_OPTIONS[level], { defaultValue: `Level ${level}` })}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                {([1, 2, 3] as const).map((level) => (
+                  <option key={level} value={level.toString()}>
+                    {t(LEVEL_OPTIONS[level], { defaultValue: `Level ${level}` })}
+                  </option>
+                ))}
+              </select>
             </div>
           </div>
           <div>
@@ -412,6 +393,18 @@ function ClassCard({ classData, onEdit, onDelete }: ClassCardProps) {
     }
   }, [classData.createdAt]);
 
+  const handleDelete = useCallback(() => {
+    const confirmed = window.confirm(
+      t('deleteDialog.description', {
+        defaultValue: 'Are you sure you want to delete this class? This action cannot be undone.',
+      }),
+    );
+
+    if (confirmed) {
+      onDelete(classData.id);
+    }
+  }, [classData.id, onDelete, t]);
+
   return (
     <motion.div
       layout
@@ -462,31 +455,15 @@ function ClassCard({ classData, onEdit, onDelete }: ClassCardProps) {
               >
                 <Edit className="h-4 w-4" />
               </Button>
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button variant="ghost" size="sm" className="text-gray-600 hover:text-red-600">
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>{t('deleteDialog.title', { defaultValue: 'Delete Class' })}</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      {t('deleteDialog.description', {
-                        defaultValue: 'Are you sure you want to delete this class? This action cannot be undone.',
-                      })}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>
-                      {t('deleteDialog.cancel', { defaultValue: 'Cancel' })}
-                    </AlertDialogCancel>
-                    <AlertDialogAction onClick={() => onDelete(classData.id)} className="bg-red-600 hover:bg-red-700">
-                      {t('deleteDialog.confirm', { defaultValue: 'Delete' })}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleDelete}
+                className="text-gray-600 hover:text-red-600"
+              >
+                <Trash2 className="h-4 w-4" />
+                <span className="sr-only">{t('deleteDialog.title', { defaultValue: 'Delete Class' })}</span>
+              </Button>
             </div>
           </div>
         </CardContent>

--- a/apps/web/src/components/teacher/MemorizationOversightSection.tsx
+++ b/apps/web/src/components/teacher/MemorizationOversightSection.tsx
@@ -10,13 +10,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
   Table,
   TableBody,
   TableCell,
@@ -169,17 +162,16 @@ export default function MemorizationOversightSection() {
       {/* Controls */}
       <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
         <div className="flex items-center gap-4">
-          <Select value={selectedClass} onValueChange={setSelectedClass}>
-            <SelectTrigger className="w-48">
-              <SelectValue placeholder={t('memorization.selectClass', { defaultValue: 'Select Class' })} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">{t('memorization.allClasses', { defaultValue: 'All Classes' })}</SelectItem>
-              <SelectItem value="1">{t('memorization.class1', { defaultValue: 'Class 1' })}</SelectItem>
-              <SelectItem value="2">{t('memorization.class2', { defaultValue: 'Class 2' })}</SelectItem>
-              <SelectItem value="3">{t('memorization.class3', { defaultValue: 'Class 3' })}</SelectItem>
-            </SelectContent>
-          </Select>
+          <select
+            value={selectedClass}
+            onChange={(event) => setSelectedClass(event.target.value)}
+            className="w-48 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+          >
+            <option value="all">{t('memorization.allClasses', { defaultValue: 'All Classes' })}</option>
+            <option value="1">{t('memorization.class1', { defaultValue: 'Class 1' })}</option>
+            <option value="2">{t('memorization.class2', { defaultValue: 'Class 2' })}</option>
+            <option value="3">{t('memorization.class3', { defaultValue: 'Class 3' })}</option>
+          </select>
         </div>
 
         <div className="flex gap-2">

--- a/apps/web/src/components/teacher/SubmissionSection.tsx
+++ b/apps/web/src/components/teacher/SubmissionSection.tsx
@@ -14,22 +14,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Textarea } from '@/components/ui/textarea';
 import { Slider } from '@/components/ui/slider';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { 
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { 
   Play, 
   Pause, 
@@ -929,39 +914,36 @@ export default function SubmissionSection() {
             />
           </div>
           
-          <Select value={filters.status} onValueChange={(value) => updateFilter('status', value)}>
-            <SelectTrigger>
-              <SelectValue placeholder={t('filterStatus', { defaultValue: 'All Status' })} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">{t('status.all', { defaultValue: 'All Status' })}</SelectItem>
-              <SelectItem value="pending">{t('status.pending', { defaultValue: 'Pending' })}</SelectItem>
-              <SelectItem value="graded">{t('status.graded', { defaultValue: 'Graded' })}</SelectItem>
-              <SelectItem value="reviewed">{t('status.reviewed', { defaultValue: 'Reviewed' })}</SelectItem>
-            </SelectContent>
-          </Select>
-          
-          <Select value={filters.assignment} onValueChange={(value) => updateFilter('assignment', value)}>
-            <SelectTrigger>
-              <SelectValue placeholder={t('filterAssignment', { defaultValue: 'All Assignments' })} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">{t('assignments.all', { defaultValue: 'All Assignments' })}</SelectItem>
-              {/* Add dynamic assignment options here */}
-            </SelectContent>
-          </Select>
-          
-          <Select value={filters.dateRange} onValueChange={(value) => updateFilter('dateRange', value)}>
-            <SelectTrigger>
-              <SelectValue placeholder={t('filterDate', { defaultValue: 'All Time' })} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">{t('dateRange.all', { defaultValue: 'All Time' })}</SelectItem>
-              <SelectItem value="today">{t('dateRange.today', { defaultValue: 'Today' })}</SelectItem>
-              <SelectItem value="week">{t('dateRange.week', { defaultValue: 'This Week' })}</SelectItem>
-              <SelectItem value="month">{t('dateRange.month', { defaultValue: 'This Month' })}</SelectItem>
-            </SelectContent>
-          </Select>
+          <select
+            value={filters.status}
+            onChange={(event) => updateFilter('status', event.target.value)}
+            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+          >
+            <option value="all">{t('status.all', { defaultValue: 'All Status' })}</option>
+            <option value="pending">{t('status.pending', { defaultValue: 'Pending' })}</option>
+            <option value="graded">{t('status.graded', { defaultValue: 'Graded' })}</option>
+            <option value="reviewed">{t('status.reviewed', { defaultValue: 'Reviewed' })}</option>
+          </select>
+
+          <select
+            value={filters.assignment}
+            onChange={(event) => updateFilter('assignment', event.target.value)}
+            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+          >
+            <option value="all">{t('assignments.all', { defaultValue: 'All Assignments' })}</option>
+            {/* Add dynamic assignment options here */}
+          </select>
+
+          <select
+            value={filters.dateRange}
+            onChange={(event) => updateFilter('dateRange', event.target.value)}
+            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+          >
+            <option value="all">{t('dateRange.all', { defaultValue: 'All Time' })}</option>
+            <option value="today">{t('dateRange.today', { defaultValue: 'Today' })}</option>
+            <option value="week">{t('dateRange.week', { defaultValue: 'This Week' })}</option>
+            <option value="month">{t('dateRange.month', { defaultValue: 'This Month' })}</option>
+          </select>
         </div>
       </div>
 

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+
+import { cn } from '@/lib/utils';
+
+interface DialogContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const DialogContext = React.createContext<DialogContextValue | undefined>(undefined);
+
+function useDialogContext(component: string) {
+  const context = React.useContext(DialogContext);
+  if (!context) {
+    throw new Error(`${component} must be used within a <Dialog>`);
+  }
+  return context;
+}
+
+export interface DialogProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function Dialog({ children, open: openProp, defaultOpen, onOpenChange }: DialogProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState<boolean>(defaultOpen ?? false);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? Boolean(openProp) : uncontrolledOpen;
+
+  const setOpen = React.useCallback(
+    (next: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(next);
+      }
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const value = React.useMemo(() => ({ open, setOpen }), [open, setOpen]);
+
+  return <DialogContext.Provider value={value}>{children}</DialogContext.Provider>;
+}
+
+export interface DialogTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
+  ({ asChild, onClick, children, ...props }, ref) => {
+    const { setOpen } = useDialogContext('DialogTrigger');
+
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children, {
+        ref,
+        onClick: (event: React.MouseEvent<HTMLElement>) => {
+          children.props.onClick?.(event);
+          onClick?.(event as unknown as React.MouseEvent<HTMLButtonElement>);
+          setOpen(true);
+        },
+      });
+    }
+
+    return (
+      <button
+        type="button"
+        ref={ref}
+        onClick={(event) => {
+          onClick?.(event);
+          setOpen(true);
+        }}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+DialogTrigger.displayName = 'DialogTrigger';
+
+export interface DialogContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
+  ({ className, children, ...props }, ref) => {
+    const { open, setOpen } = useDialogContext('DialogContent');
+    const [mounted, setMounted] = React.useState(false);
+
+    React.useEffect(() => {
+      setMounted(true);
+    }, []);
+
+    if (!open || !mounted || typeof document === 'undefined') {
+      return null;
+    }
+
+    return createPortal(
+      <div className="fixed inset-0 z-50 flex items-center justify-center">
+        <div
+          className="absolute inset-0 bg-black/40"
+          onClick={() => setOpen(false)}
+          aria-hidden="true"
+        />
+        <div
+          ref={ref}
+          role="dialog"
+          aria-modal="true"
+          className={cn(
+            'relative z-50 w-full max-w-lg rounded-xl bg-white p-6 shadow-xl outline-none dark:bg-gray-900',
+            className,
+          )}
+          onClick={(event) => event.stopPropagation()}
+          {...props}
+        >
+          {children}
+        </div>
+      </div>,
+      document.body,
+    );
+  },
+);
+DialogContent.displayName = 'DialogContent';
+
+export const DialogHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('space-y-1.5 text-center sm:text-left', className)} {...props} />
+  ),
+);
+DialogHeader.displayName = 'DialogHeader';
+
+export const DialogFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)} {...props} />
+  ),
+);
+DialogFooter.displayName = 'DialogFooter';
+
+export const DialogTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h2 ref={ref} className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+  ),
+);
+DialogTitle.displayName = 'DialogTitle';
+
+export const DialogDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-gray-600 dark:text-gray-400', className)} {...props} />
+  ),
+);
+DialogDescription.displayName = 'DialogDescription';

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = 'text', ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition-colors focus:border-transparent focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-white',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = 'Input';
+
+export default Input;

--- a/apps/web/src/components/ui/progress.tsx
+++ b/apps/web/src/components/ui/progress.tsx
@@ -1,31 +1,36 @@
-/* AlFawz Qur'an Institute — generated with TRAE */
-/* Author: Auto-scaffold (review required) */
+import * as React from 'react';
 
-import * as React from "react";
-import * as ProgressPrimitive from "@radix-ui/react-progress";
-import { cn } from "@/lib/utils";
+import { cn } from '@/lib/utils';
 
-/**
- * Progress component for displaying completion status.
- */
-const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
-      className
-    )}
-    {...props}
-  >
-    <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-    />
-  </ProgressPrimitive.Root>
-));
-Progress.displayName = ProgressPrimitive.Root.displayName;
+export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: number;
+  max?: number;
+}
 
-export { Progress };
+export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ className, value = 0, max = 100, ...props }, ref) => {
+    const safeMax = max <= 0 ? 100 : max;
+    const clampedValue = Math.min(Math.max(value, 0), safeMax);
+    const percentage = Math.min(Math.max((clampedValue / safeMax) * 100, 0), 100);
+
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={safeMax}
+        aria-valuenow={clampedValue}
+        className={cn('relative h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-800', className)}
+        {...props}
+      >
+        <div
+          className="h-full bg-emerald-500 transition-all dark:bg-emerald-400"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    );
+  },
+);
+Progress.displayName = 'Progress';
+
+export default Progress;

--- a/apps/web/src/components/ui/scroll-area.tsx
+++ b/apps/web/src/components/ui/scroll-area.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type ScrollAreaProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={cn('relative overflow-auto', className)}
+      {...props}
+    />
+  );
+});
+ScrollArea.displayName = 'ScrollArea';
+
+export default ScrollArea;

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type SkeletonProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={cn('animate-pulse rounded-md bg-gray-200 dark:bg-gray-700', className)}
+      {...props}
+    />
+  );
+});
+Skeleton.displayName = 'Skeleton';
+
+export default Skeleton;

--- a/apps/web/src/components/ui/slider.tsx
+++ b/apps/web/src/components/ui/slider.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface SliderProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'defaultValue' | 'onChange'> {
+  value?: number[];
+  defaultValue?: number[];
+  onValueChange?: (value: number[]) => void;
+}
+
+export const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
+  ({ className, value, defaultValue, onValueChange, min = 0, max = 100, step = 1, disabled, ...props }, ref) => {
+    const [internalValue, setInternalValue] = React.useState<number>(
+      () => value?.[0] ?? defaultValue?.[0] ?? (typeof min === 'number' ? Number(min) : 0),
+    );
+
+    React.useEffect(() => {
+      if (value !== undefined && typeof value[0] === 'number') {
+        setInternalValue(value[0]);
+      }
+    }, [value]);
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const nextValue = Number(event.target.value);
+      if (value === undefined) {
+        setInternalValue(nextValue);
+      }
+      onValueChange?.([nextValue]);
+    };
+
+    return (
+      <input
+        ref={ref}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        value={value?.[0] ?? internalValue}
+        onChange={handleChange}
+        className={cn(
+          'h-2 w-full cursor-pointer appearance-none rounded-full bg-gray-200 accent-emerald-600 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-gray-700',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Slider.displayName = 'Slider';
+
+export default Slider;

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export const Table = React.forwardRef<HTMLTableElement, React.TableHTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <table
+      ref={ref}
+      className={cn('w-full caption-bottom text-sm text-left text-gray-700 dark:text-gray-200', className)}
+      {...props}
+    />
+  ),
+);
+Table.displayName = 'Table';
+
+export const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={cn('bg-gray-100 dark:bg-gray-800 text-xs uppercase tracking-wide', className)} {...props} />
+  ),
+);
+TableHeader.displayName = 'TableHeader';
+
+export const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn('divide-y divide-gray-200 dark:divide-gray-700', className)} {...props} />
+  ),
+);
+TableBody.displayName = 'TableBody';
+
+export const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn('transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/60', className)}
+      {...props}
+    />
+  ),
+);
+TableRow.displayName = 'TableRow';
+
+export const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn('px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-200', className)}
+      {...props}
+    />
+  ),
+);
+TableHead.displayName = 'TableHead';
+
+export const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td ref={ref} className={cn('px-4 py-3 align-middle', className)} {...props} />
+  ),
+);
+TableCell.displayName = 'TableCell';
+
+export default Table;

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -1,67 +1,146 @@
-/* AlFawz Qur'an Institute — generated with TRAE */
-/* Author: Auto-scaffold (review required) */
+import * as React from 'react';
 
-import * as React from "react";
-import * as TabsPrimitive from "@radix-ui/react-tabs";
-import { cn } from "@/lib/utils";
+import { cn } from '@/lib/utils';
 
-/**
- * Tabs root component for organizing content into tabs.
- */
-const Tabs = TabsPrimitive.Root;
+interface TabsContextValue {
+  value: string;
+  setValue: (value: string) => void;
+  id: string;
+}
 
-/**
- * Tabs list component containing tab triggers.
- */
-const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
-      className
-    )}
-    {...props}
-  />
-));
-TabsList.displayName = TabsPrimitive.List.displayName;
+const TabsContext = React.createContext<TabsContextValue | undefined>(undefined);
 
-/**
- * Individual tab trigger component.
- */
-const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
-      className
-    )}
-    {...props}
-  />
-));
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+function useTabsContext(component: string) {
+  const context = React.useContext(TabsContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Tabs>`);
+  }
+  return context;
+}
 
-/**
- * Tab content component for displaying tab panel content.
- */
-const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
-    )}
-    {...props}
-  />
-));
-TabsContent.displayName = TabsPrimitive.Content.displayName;
+export interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+}
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export const Tabs: React.FC<TabsProps> = ({
+  value: controlledValue,
+  defaultValue,
+  onValueChange,
+  className,
+  children,
+  ...props
+}) => {
+  const isControlled = controlledValue !== undefined;
+  const [internalValue, setInternalValue] = React.useState(defaultValue ?? '');
+  const value = isControlled ? controlledValue! : internalValue;
+  const reactId = React.useId();
+
+  const setValue = React.useCallback(
+    (next: string) => {
+      if (!isControlled) {
+        setInternalValue(next);
+      }
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const context = React.useMemo<TabsContextValue>(
+    () => ({ value, setValue, id: reactId }),
+    [reactId, setValue, value],
+  );
+
+  return (
+    <TabsContext.Provider value={context}>
+      <div className={cn('space-y-2', className)} {...props}>
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+};
+
+export interface TabsListProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="tablist"
+      className={cn(
+        'inline-flex h-10 items-center justify-center rounded-md bg-gray-100 p-1 text-gray-500 dark:bg-gray-800 dark:text-gray-300',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+TabsList.displayName = 'TabsList';
+
+export interface TabsTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  value: string;
+}
+
+export const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>(
+  ({ className, value, onClick, ...props }, ref) => {
+    const { value: activeValue, setValue, id } = useTabsContext('TabsTrigger');
+    const isActive = activeValue === value;
+    const triggerId = `${id}-trigger-${value}`;
+    const panelId = `${id}-panel-${value}`;
+
+    return (
+      <button
+        type="button"
+        ref={ref}
+        id={triggerId}
+        role="tab"
+        aria-selected={isActive}
+        aria-controls={panelId}
+        data-state={isActive ? 'active' : 'inactive'}
+        className={cn(
+          'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm dark:focus-visible:ring-offset-gray-900 dark:data-[state=active]:bg-gray-900 dark:data-[state=active]:text-white',
+          className,
+        )}
+        onClick={(event) => {
+          onClick?.(event);
+          setValue(value);
+        }}
+        {...props}
+      />
+    );
+  },
+);
+TabsTrigger.displayName = 'TabsTrigger';
+
+export interface TabsContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: string;
+}
+
+export const TabsContent = React.forwardRef<HTMLDivElement, TabsContentProps>(
+  ({ className, value, ...props }, ref) => {
+    const { value: activeValue, id } = useTabsContext('TabsContent');
+    const isActive = activeValue === value;
+    const panelId = `${id}-panel-${value}`;
+    const triggerId = `${id}-trigger-${value}`;
+
+    return (
+      <div
+        ref={ref}
+        id={panelId}
+        role="tabpanel"
+        aria-labelledby={triggerId}
+        hidden={!isActive}
+        data-state={isActive ? 'active' : 'inactive'}
+        className={cn(
+          'mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+TabsContent.displayName = 'TabsContent';
+
+export default Tabs;

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        className={cn(
+          'flex min-h-[80px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition-colors focus:border-transparent focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-white',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = 'Textarea';
+
+export default Textarea;

--- a/apps/web/src/hooks/useAssignments.ts
+++ b/apps/web/src/hooks/useAssignments.ts
@@ -1,0 +1,87 @@
+import { useCallback, useState } from 'react';
+
+import { Assignment, Submission } from '../types/assignment';
+
+interface UseAssignmentsResult {
+  assignments: Assignment[];
+  submissions: Submission[];
+  loading: boolean;
+  error: string | null;
+  fetchAssignments: () => Promise<void>;
+}
+
+const parseAssignments = (payload: unknown): Assignment[] => {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload as Assignment[];
+  if (typeof payload === 'object' && Array.isArray((payload as { data?: Assignment[] }).data)) {
+    return (payload as { data: Assignment[] }).data;
+  }
+  return [];
+};
+
+const parseSubmissions = (payload: unknown): Submission[] => {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload as Submission[];
+  if (typeof payload === 'object' && Array.isArray((payload as { data?: Submission[] }).data)) {
+    return (payload as { data: Submission[] }).data;
+  }
+  return [];
+};
+
+export const useAssignments = (): UseAssignmentsResult => {
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [submissions, setSubmissions] = useState<Submission[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAssignments = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+      const headers: HeadersInit = {
+        'Content-Type': 'application/json',
+      };
+
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+
+      const [assignmentsResponse, submissionsResponse] = await Promise.all([
+        fetch('/api/assignments', { headers }),
+        fetch('/api/submissions', { headers }),
+      ]);
+
+      if (!assignmentsResponse.ok) {
+        throw new Error(`Failed to load assignments: ${assignmentsResponse.statusText}`);
+      }
+
+      if (!submissionsResponse.ok) {
+        throw new Error(`Failed to load submissions: ${submissionsResponse.statusText}`);
+      }
+
+      const assignmentsData = await assignmentsResponse.json();
+      const submissionsData = await submissionsResponse.json();
+
+      setAssignments(parseAssignments(assignmentsData));
+      setSubmissions(parseSubmissions(submissionsData));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to load assignments';
+      setError(message);
+      console.error('Assignments fetch error:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    assignments,
+    submissions,
+    loading,
+    error,
+    fetchAssignments,
+  };
+};
+
+export default useAssignments;

--- a/apps/web/src/hooks/useAuth.tsx
+++ b/apps/web/src/hooks/useAuth.tsx
@@ -2,6 +2,7 @@
 /* Author: Auto-scaffold (review required) */
 
 import { useState, useEffect, createContext, useContext } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 
 interface User {
   id: number;
@@ -241,21 +242,21 @@ export const useAuthImplementation = (): AuthContextType => {
 /**
  * Auth Provider component to wrap the app.
  */
-export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export function AuthProvider({ children }: { children: ReactNode }) {
   const auth = useAuthImplementation();
-  
+
   return (
     <AuthContext.Provider value={auth}>
       {children}
     </AuthContext.Provider>
   );
-};
+}
 
 /**
  * Higher-order component for protecting routes.
  * Redirects to login if user is not authenticated.
  */
-export const withAuth = <P extends object>(Component: React.ComponentType<P>) => {
+export const withAuth = <P extends object>(Component: ComponentType<P>) => {
   return function AuthenticatedComponent(props: P) {
     const { user, loading } = useAuth();
     

--- a/apps/web/src/i18n/navigation.ts
+++ b/apps/web/src/i18n/navigation.ts
@@ -1,0 +1,8 @@
+import { createNavigation } from 'next-intl/navigation';
+
+import { defaultLocale, locales } from './request';
+
+export const { Link, useRouter, usePathname, redirect, getPathname } = createNavigation({
+  locales,
+  defaultLocale,
+});

--- a/apps/web/src/lib/accessibility.tsx
+++ b/apps/web/src/lib/accessibility.tsx
@@ -1,6 +1,8 @@
 /* AlFawz Qur'an Institute — generated with TRAE */
 /* Author: Auto-scaffold (review required) */
 
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+
 /**
  * Accessibility utilities for screen readers and keyboard navigation
  */
@@ -11,6 +13,10 @@
  * @param priority 'polite' (default) or 'assertive'
  */
 export function announceToScreenReader(message: string, priority: 'polite' | 'assertive' = 'polite') {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
   const announcement = document.createElement('div');
   announcement.setAttribute('aria-live', priority);
   announcement.setAttribute('aria-atomic', 'true');
@@ -30,10 +36,7 @@ export function announceToScreenReader(message: string, priority: 'polite' | 'as
  * @param event Keyboard event
  * @param callback Function to execute on Enter/Space
  */
-export function handleKeyboardActivation(
-  event: React.KeyboardEvent,
-  callback: () => void
-) {
+export function handleKeyboardActivation(event: ReactKeyboardEvent, callback: () => void) {
   if (event.key === 'Enter' || event.key === ' ') {
     event.preventDefault();
     callback();
@@ -113,7 +116,7 @@ export const focusManagement = {
  * @param text Text for screen readers only
  * @returns JSX element with sr-only class
  */
-export function ScreenReaderOnly({ children }: { children: React.ReactNode }) {
+export function ScreenReaderOnly({ children }: { children: ReactNode }) {
   return (
     <span className="sr-only">
       {children}
@@ -124,12 +127,12 @@ export function ScreenReaderOnly({ children }: { children: React.ReactNode }) {
 /**
  * ARIA live region component for dynamic announcements
  */
-export function LiveRegion({ 
-  message, 
-  priority = 'polite' 
-}: { 
-  message: string; 
-  priority?: 'polite' | 'assertive' 
+export function LiveRegion({
+  message,
+  priority = 'polite'
+}: {
+  message: string;
+  priority?: 'polite' | 'assertive'
 }) {
   return (
     <div
@@ -145,7 +148,7 @@ export function LiveRegion({
 /**
  * Skip link component for keyboard navigation
  */
-export function SkipLink({ href, children }: { href: string; children: React.ReactNode }) {
+export function SkipLink({ href, children }: { href: string; children: ReactNode }) {
   return (
     <a
       href={href}


### PR DESCRIPTION
## Summary
- add @heroicons/react and replace missing shadcn UI primitives with lightweight local components (dialog, input, slider, table, etc.)
- update teacher dashboards to use native selects and browser confirmation instead of unavailable select/alert-dialog modules
- create next-intl navigation helper, convert auth/accessibility utilities to TSX, and add a useAssignments hook to satisfy runtime imports

## Testing
- npm run build *(passes with existing ESLint warnings about legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc4d3427883278d447f623a019ad0