### PR TITLE
Handle async locale params and align memorization types

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/page.tsx
@@ -3,15 +3,19 @@
 
 import { redirect } from 'next/navigation';
 
-type Props = {
-  params: { locale: string };
+type LocalizedParams = {
+  params?: Promise<{ locale?: string }>;
+  searchParams?: Promise<Record<string, unknown>>;
 };
 
 /**
  * Localized dashboard page.
  * Redirects to the main dashboard with proper locale handling.
  */
-export default function LocalizedDashboard({ params: { locale } }: Props) {
+export default async function LocalizedDashboard({ params }: LocalizedParams) {
+  if (params) {
+    await params;
+  }
   // Redirect to the main dashboard page
   // The middleware will handle locale prefixing
   redirect('/dashboard');
@@ -20,7 +24,9 @@ export default function LocalizedDashboard({ params: { locale } }: Props) {
 /**
  * Generate metadata for the localized dashboard page.
  */
-export async function generateMetadata({ params: { locale } }: Props) {
+export async function generateMetadata({ params }: LocalizedParams) {
+  const resolvedParams = (await params) ?? {};
+  const locale = typeof resolvedParams.locale === 'string' ? resolvedParams.locale : 'en';
   const titles = {
     en: 'Dashboard - AlFawz Qur\'an Institute',
     ar: 'لوحة التحكم - معهد الفوز للقرآن'

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,14 +1,15 @@
 /* AlFawz Qur'an Institute — generated with TRAE */
 /* Author: Auto-scaffold (review required) */
 
+import type { ReactNode } from 'react';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { isLocale, locales } from '@/i18n';
 
 type Props = {
-  children: React.ReactNode;
-  params: { locale: string };
+  children: ReactNode;
+  params?: Promise<{ locale?: string }>;
 };
 
 /**
@@ -17,10 +18,12 @@ type Props = {
  */
 export default async function LocaleLayout({
   children,
-  params: { locale }
+  params,
 }: Props) {
+  const resolvedParams = (await params) ?? {};
+  const locale = typeof resolvedParams.locale === 'string' ? resolvedParams.locale : undefined;
   // Validate that the incoming `locale` parameter is valid
-  if (!isLocale(locale)) {
+  if (!locale || !isLocale(locale)) {
     notFound();
   }
 

--- a/apps/web/src/types/heroicons.d.ts
+++ b/apps/web/src/types/heroicons.d.ts
@@ -1,0 +1,1 @@
+declare module '@heroicons/react/outline';


### PR DESCRIPTION
## Summary
- update localized dashboard page and layout to accept async params when resolving locale metadata
- tighten memorization section to use hook-defined types, clear audio properly, and support optional className
- add a local declaration for `@heroicons/react/outline` to satisfy TypeScript during builds

## Testing
- `npm run build` *(fails: upstream lint/type issues such as missing lucide-react exports)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf42671d08327a1d29365fa3a574d