### PR TITLE
Add Geist font directories to web app public assets

### DIFF
--- a/apps/web/public/fonts/geist-mono/.gitkeep
+++ b/apps/web/public/fonts/geist-mono/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory tracked.

--- a/apps/web/public/fonts/geist-sans/.gitkeep
+++ b/apps/web/public/fonts/geist-sans/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory tracked.


### PR DESCRIPTION
## Summary
- add missing Geist Mono and Geist Sans font directories under the web app public assets
- include placeholder files so the new directories remain tracked in Git

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ce43299e388327a43693938433e1e9