### PR TITLE
Wrap profile fetch in useCallback

### DIFF
--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -3,7 +3,7 @@
 
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { ApiError, api } from '@/lib/api';
 import { formatHasanat, getHasanatBadge } from '@/lib/hasanat';
@@ -42,7 +42,7 @@ export default function ProfilePage() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
 
-  const getErrorMessage = (caught: unknown, fallback: string) => {
+  const getErrorMessage = useCallback((caught: unknown, fallback: string) => {
     if (caught instanceof ApiError) {
       return caught.message;
     }
@@ -52,12 +52,12 @@ export default function ProfilePage() {
     }
 
     return fallback;
-  };
+  }, []);
 
   /**
    * Fetch user profile data and statistics
    */
-  const fetchProfileData = async () => {
+  const fetchProfileData = useCallback(async () => {
     try {
       setLoading(true);
       setError('');
@@ -95,7 +95,7 @@ export default function ProfilePage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [getErrorMessage, user]);
 
   /**
    * Update user profile
@@ -140,7 +140,7 @@ export default function ProfilePage() {
     if (isAuthenticated && user) {
       fetchProfileData();
     }
-  }, [isAuthenticated, user]);
+  }, [fetchProfileData, isAuthenticated, user]);
 
   if (!isAuthenticated) {
     return (


### PR DESCRIPTION
## Summary
- memoize the profile fetch helper with `useCallback` to avoid recreations on re-render
- add the memoized function to the profile effect dependencies and memoize the shared error helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce6c9a15788327b27938e06ca2e27d