### PR TITLE
Fix audio components lint warnings

### DIFF
--- a/apps/web/src/components/assignment/AudioRecorder.tsx
+++ b/apps/web/src/components/assignment/AudioRecorder.tsx
@@ -74,7 +74,7 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       setHasPermission(true);
       stream.getTracks().forEach(track => track.stop());
-    } catch (err) {
+    } catch (_error) {
       setHasPermission(false);
       setError('Microphone access denied. Please allow microphone access to record audio.');
     }

--- a/apps/web/src/components/assignment/AudioTooltip.tsx
+++ b/apps/web/src/components/assignment/AudioTooltip.tsx
@@ -10,14 +10,10 @@ import {
   Pause,
   SkipBack,
   SkipForward,
-  RotateCcw,
   Download,
   Headphones,
-  Waveform,
   Clock,
-  Star,
-  Heart,
-  BookOpen
+  Star
 } from 'lucide-react';
 
 interface AudioTooltipProps {


### PR DESCRIPTION
## Summary
- rename the unused AudioRecorder catch parameter to `_error`
- remove unused lucide-react icons from AudioTooltip

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce6c9c7b3c83279dd80447a4693d38