### PR TITLE
refactor: optimize assignment image components

### DIFF
--- a/apps/web/src/components/assignment/CoordinateMapper.tsx
+++ b/apps/web/src/components/assignment/CoordinateMapper.tsx
@@ -2,16 +2,14 @@
 /* Author: Auto-scaffold (review required) */
 
 import React, { useState, useRef, useCallback, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import Image from 'next/image';
+import { motion } from 'framer-motion';
 import {
   MousePointer,
-  Move,
   RotateCcw,
   ZoomIn,
   ZoomOut,
-  Grid,
   Crosshair,
-  Save,
   Undo,
   Redo,
   Trash2
@@ -57,7 +55,7 @@ const CoordinateMapper: React.FC<CoordinateMapperProps> = ({
 }) => {
   // Container and image refs
   const containerRef = useRef<HTMLDivElement>(null);
-  const imageRef = useRef<HTMLImageElement>(null);
+  const imageRef = useRef<HTMLImageElement | null>(null);
   
   // State management
   const [dragState, setDragState] = useState<DragState>({
@@ -103,7 +101,6 @@ const CoordinateMapper: React.FC<CoordinateMapperProps> = ({
   const screenToImageCoordinates = useCallback((screenX: number, screenY: number) => {
     if (!containerRef.current || !imageRef.current) return { x: 0, y: 0 };
     
-    const containerRect = containerRef.current.getBoundingClientRect();
     const imageRect = imageRef.current.getBoundingClientRect();
     
     // Calculate relative position within the image
@@ -479,18 +476,21 @@ const CoordinateMapper: React.FC<CoordinateMapperProps> = ({
         )}
         
         {/* Image */}
-        <img
+        <Image
           ref={imageRef}
           src={imageUrl}
           alt="Assignment base image"
           className="w-full h-auto block"
           onLoad={handleImageLoad}
           draggable={false}
+          width={Math.max(1, imageDimensions.width)}
+          height={Math.max(1, imageDimensions.height)}
+          sizes="100vw"
+          unoptimized
         />
-        
+
         {/* Hotspots */}
         {imageLoaded && hotspots.map((hotspot) => {
-          const screenCoords = imageToScreenCoordinates(hotspot.x, hotspot.y);
           const isSelected = selectedHotspot === hotspot.id;
           const isDragging = dragState.draggedHotspot?.id === hotspot.id;
           

--- a/apps/web/src/components/assignment/HotspotEditor.tsx
+++ b/apps/web/src/components/assignment/HotspotEditor.tsx
@@ -2,6 +2,7 @@
 /* Author: Auto-scaffold (review required) */
 
 import React, { useState, useRef, useCallback } from 'react';
+import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Plus,
@@ -9,14 +10,11 @@ import {
   Volume2,
   Info,
   Settings,
-  Play,
-  Square,
-  Move,
   RotateCcw,
   Eye,
   EyeOff
 } from 'lucide-react';
-import { CreateHotspotData, Hotspot, HotspotAnimation } from '../../types/assignment';
+import { CreateHotspotData, HotspotAnimation } from '../../types/assignment';
 
 const HOTSPOT_TYPES = ['text', 'audio', 'interactive', 'quiz'] as const;
 type HotspotType = (typeof HOTSPOT_TYPES)[number];
@@ -73,12 +71,20 @@ const HotspotEditor: React.FC<HotspotEditorProps> = ({
 }) => {
   const [isCreatingHotspot, setIsCreatingHotspot] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
-  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
   const [showHotspots, setShowHotspots] = useState(true);
   const [deletedHotspots, setDeletedHotspots] = useState<number[]>([]);
-  
-  const imageRef = useRef<HTMLImageElement>(null);
+
+  const imageRef = useRef<HTMLImageElement | null>(null);
   const audioInputRef = useRef<HTMLInputElement>(null);
+  const [imageDimensions, setImageDimensions] = useState({ width: 1, height: 1 });
+
+  const handleImageLoad = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {
+    const { naturalWidth, naturalHeight } = event.currentTarget;
+
+    if (naturalWidth > 0 && naturalHeight > 0) {
+      setImageDimensions({ width: naturalWidth, height: naturalHeight });
+    }
+  }, []);
 
   /**
    * Handle image click to create new hotspot.
@@ -130,10 +136,9 @@ const HotspotEditor: React.FC<HotspotEditorProps> = ({
     const offsetX = event.clientX - rect.left;
     const offsetY = event.clientY - rect.top;
     
-    setDragOffset({ x: offsetX, y: offsetY });
     setIsDragging(true);
     onSelectedHotspotChange(hotspotId);
-    
+
     const handleMouseMove = (e: MouseEvent) => {
       if (!imageRef.current) return;
       
@@ -287,13 +292,18 @@ const HotspotEditor: React.FC<HotspotEditorProps> = ({
       <div className="relative bg-gray-50 rounded-lg overflow-hidden">
         {imageUrl ? (
           <div className="relative">
-            <img
+            <Image
               ref={imageRef}
               src={imageUrl}
               alt="Assignment"
               className={`w-full h-auto ${!readOnly ? 'cursor-crosshair' : ''}`}
               onClick={handleImageClick}
+              onLoad={handleImageLoad}
               draggable={false}
+              width={imageDimensions.width}
+              height={imageDimensions.height}
+              sizes="100vw"
+              unoptimized
             />
             
             {/* Render Hotspots */}


### PR DESCRIPTION
## Summary
- replace assignment editor and mapper <img> usage with Next.js Image, including dynamic sizing and unoptimized loading for remote assets
- drop unused icons, refs, and locals to keep the hotspot editors lint-clean
- align image refs with HTMLImageElement|null typing to work with next/image refs

## Testing
- npm run lint *(warnings only from pre-existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6cbc219c8327a3c2c1f0fe89e9b8