### PR TITLE
Refine teacher assignment pages

### DIFF
--- a/apps/web/src/pages/teacher/assignments/[id].tsx
+++ b/apps/web/src/pages/teacher/assignments/[id].tsx
@@ -1,7 +1,8 @@
 /* AlFawz Qur'an Institute — generated with TRAE */
 /* Author: Auto-scaffold (review required) */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/router';
 import {
@@ -10,24 +11,14 @@ import {
   Users,
   Calendar,
   Clock,
-  CheckCircle,
   AlertCircle,
   Play,
   Pause,
-  Volume2,
-  Download,
-  Star,
-  MessageSquare,
   Send,
-  Eye,
-  Filter,
   Search,
-  BarChart3,
-  FileText,
-  Mic
+  FileText
 } from 'lucide-react';
 import Layout from '../../../components/Layout';
-import { useAuth } from '../../../hooks/useAuth';
 import { Assignment, Submission, Feedback, SubmissionStatus } from '../../../types/assignment';
 import HotspotComponent from '../../../components/assignment/HotspotComponent';
 
@@ -55,7 +46,6 @@ interface AssignmentWithSubmissions extends Assignment {
 const TeacherAssignmentDetailPage: React.FC = () => {
   const router = useRouter();
   const { id } = router.query;
-  const { user } = useAuth();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [assignment, setAssignment] = useState<AssignmentWithSubmissions | null>(null);
@@ -71,7 +61,8 @@ const TeacherAssignmentDetailPage: React.FC = () => {
   /**
    * Fetch assignment details with submissions.
    */
-  const fetchAssignment = async () => {
+  const fetchAssignment = useCallback(async () => {
+    if (!id) return;
     try {
       setLoading(true);
       setError(null);
@@ -100,7 +91,7 @@ const TeacherAssignmentDetailPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [id]);
 
   /**
    * Submit feedback for a submission.
@@ -235,7 +226,7 @@ const TeacherAssignmentDetailPage: React.FC = () => {
     if (id) {
       fetchAssignment();
     }
-  }, [id]);
+  }, [id, fetchAssignment]);
 
   useEffect(() => {
     // Cleanup audio on unmount
@@ -348,10 +339,13 @@ const TeacherAssignmentDetailPage: React.FC = () => {
                 <div className="relative">
                   {assignment.image_url ? (
                     <div className="relative">
-                      <img
+                      <Image
                         src={assignment.image_url}
                         alt={assignment.title}
+                        width={1200}
+                        height={800}
                         className="w-full h-auto"
+                        unoptimized
                       />
                       
                       {/* Render Hotspots */}

--- a/apps/web/src/pages/teacher/assignments/[id]/edit.tsx
+++ b/apps/web/src/pages/teacher/assignments/[id]/edit.tsx
@@ -2,6 +2,7 @@
 /* Author: Auto-scaffold (review required) */
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/router';
 import {
@@ -11,19 +12,13 @@ import {
   Trash2,
   Save,
   Eye,
-  Calendar,
-  Users,
   Image as ImageIcon,
   Volume2,
   Info,
-  Settings,
-  Play,
-  Square,
   AlertCircle
 } from 'lucide-react';
 import Layout from '../../../../components/Layout';
-import { useAuth } from '../../../../hooks/useAuth';
-import { Assignment, UpdateAssignmentData, CreateHotspotData, ClassInfo, Hotspot } from '../../../../types/assignment';
+import { Assignment, UpdateAssignmentData, CreateHotspotData, Hotspot } from '../../../../types/assignment';
 
 interface HotspotDraft extends Omit<CreateHotspotData, 'audio'> {
   id: string | number;
@@ -43,7 +38,6 @@ interface AssignmentWithHotspots extends Assignment {
 const EditAssignmentPage: React.FC = () => {
   const router = useRouter();
   const { id } = router.query;
-  const { user } = useAuth();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -64,18 +58,18 @@ const EditAssignmentPage: React.FC = () => {
   const [hotspots, setHotspots] = useState<HotspotDraft[]>([]);
   const [selectedHotspot, setSelectedHotspot] = useState<string | number | null>(null);
   const [isCreatingHotspot, setIsCreatingHotspot] = useState(false);
-  const [classes, setClasses] = useState<ClassInfo[]>([]);
   const [deletedHotspots, setDeletedHotspots] = useState<number[]>([]);
-  
+
   // Refs
-  const imageRef = useRef<HTMLImageElement>(null);
+  const imageRef = useRef<HTMLImageElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const audioInputRef = useRef<HTMLInputElement>(null);
 
   /**
    * Fetch assignment data for editing.
    */
-  const fetchAssignment = async () => {
+  const fetchAssignment = useCallback(async () => {
+    if (!id) return;
     try {
       setLoading(true);
       setError(null);
@@ -142,7 +136,7 @@ const EditAssignmentPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [id]);
 
   /**
    * Handle form input changes.
@@ -343,7 +337,7 @@ const EditAssignmentPage: React.FC = () => {
     if (id) {
       fetchAssignment();
     }
-  }, [id]);
+  }, [id, fetchAssignment]);
 
   const selectedHotspotData = hotspots.find(h => h.id === selectedHotspot);
 
@@ -684,10 +678,13 @@ const EditAssignmentPage: React.FC = () => {
                 <div className="relative">
                   {imageUrl ? (
                     <div className="relative">
-                      <img
+                      <Image
                         ref={imageRef}
                         src={imageUrl}
                         alt="Assignment"
+                        width={1200}
+                        height={800}
+                        unoptimized
                         className="w-full h-auto cursor-crosshair"
                         onClick={handleImageClick}
                       />

--- a/apps/web/src/pages/teacher/assignments/create.tsx
+++ b/apps/web/src/pages/teacher/assignments/create.tsx
@@ -2,6 +2,7 @@
 /* Author: Auto-scaffold (review required) */
 
 import React, { useState, useRef, useCallback } from 'react';
+import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/router';
 import {
@@ -11,18 +12,12 @@ import {
   Trash2,
   Save,
   Eye,
-  Calendar,
-  Users,
   Image as ImageIcon,
   Volume2,
-  Info,
-  Settings,
-  Play,
-  Square
+  Info
 } from 'lucide-react';
 import Layout from '../../../components/Layout';
-import { useAuth } from '../../../hooks/useAuth';
-import { CreateAssignmentData, CreateHotspotData, ClassInfo } from '../../../types/assignment';
+import { CreateAssignmentData, CreateHotspotData } from '../../../types/assignment';
 
 const HOTSPOT_TYPES = ['text', 'audio', 'interactive', 'quiz'] as const;
 type HotspotType = (typeof HOTSPOT_TYPES)[number];
@@ -43,7 +38,6 @@ interface HotspotDraft extends Omit<CreateHotspotData, 'audio'> {
  */
 const CreateAssignmentPage: React.FC = () => {
   const router = useRouter();
-  const { user } = useAuth();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   
@@ -62,10 +56,9 @@ const CreateAssignmentPage: React.FC = () => {
   const [hotspots, setHotspots] = useState<HotspotDraft[]>([]);
   const [selectedHotspot, setSelectedHotspot] = useState<string | null>(null);
   const [isCreatingHotspot, setIsCreatingHotspot] = useState(false);
-  const [classes, setClasses] = useState<ClassInfo[]>([]);
-  
+
   // Refs
-  const imageRef = useRef<HTMLImageElement>(null);
+  const imageRef = useRef<HTMLImageElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const audioInputRef = useRef<HTMLInputElement>(null);
 
@@ -546,10 +539,13 @@ const CreateAssignmentPage: React.FC = () => {
                 <div className="relative">
                   {imageUrl ? (
                     <div className="relative">
-                      <img
+                      <Image
                         ref={imageRef}
                         src={imageUrl}
                         alt="Assignment"
+                        width={1200}
+                        height={800}
+                        unoptimized
                         className="w-full h-auto cursor-crosshair"
                         onClick={handleImageClick}
                       />

--- a/apps/web/src/pages/teacher/assignments/index.tsx
+++ b/apps/web/src/pages/teacher/assignments/index.tsx
@@ -1,7 +1,8 @@
 /* AlFawz Qur'an Institute — generated with TRAE */
 /* Author: Auto-scaffold (review required) */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/router';
 import {
@@ -18,12 +19,10 @@ import {
   CheckCircle,
   AlertCircle,
   FileText,
-  Image as ImageIcon,
-  Volume2
+  Image as ImageIcon
 } from 'lucide-react';
 import Layout from '../../../components/Layout';
-import { useAuth } from '../../../hooks/useAuth';
-import { Assignment, AssignmentStatus, AssignmentFilters } from '../../../types/assignment';
+import { Assignment, AssignmentStatus } from '../../../types/assignment';
 
 interface AssignmentWithStats extends Assignment {
   submissions_count: number;
@@ -37,7 +36,6 @@ interface AssignmentWithStats extends Assignment {
  */
 const TeacherAssignmentsPage: React.FC = () => {
   const router = useRouter();
-  const { user } = useAuth();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [assignments, setAssignments] = useState<AssignmentWithStats[]>([]);
@@ -50,7 +48,7 @@ const TeacherAssignmentsPage: React.FC = () => {
   /**
    * Fetch assignments from API.
    */
-  const fetchAssignments = async () => {
+  const fetchAssignments = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -79,14 +77,14 @@ const TeacherAssignmentsPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   /**
    * Filter assignments based on search term and status.
    */
-  const filterAssignments = () => {
+  const filterAssignments = useCallback(() => {
     let filtered = assignments;
-    
+
     // Filter by search term
     if (searchTerm.trim()) {
       const term = searchTerm.toLowerCase();
@@ -101,9 +99,9 @@ const TeacherAssignmentsPage: React.FC = () => {
     if (statusFilter !== 'all') {
       filtered = filtered.filter(assignment => assignment.status === statusFilter);
     }
-    
+
     setFilteredAssignments(filtered);
-  };
+  }, [assignments, searchTerm, statusFilter]);
 
   /**
    * Delete assignment.
@@ -211,11 +209,11 @@ const TeacherAssignmentsPage: React.FC = () => {
 
   useEffect(() => {
     fetchAssignments();
-  }, []);
+  }, [fetchAssignments]);
 
   useEffect(() => {
     filterAssignments();
-  }, [assignments, searchTerm, statusFilter]);
+  }, [filterAssignments]);
 
   if (loading) {
     return (
@@ -348,10 +346,13 @@ const TeacherAssignmentsPage: React.FC = () => {
                       {/* Assignment Image */}
                       <div className="relative h-48 bg-gradient-to-br from-maroon-100 to-gold-100">
                         {assignment.image_url ? (
-                          <img
+                          <Image
                             src={assignment.image_url}
                             alt={assignment.title}
-                            className="w-full h-full object-cover"
+                            fill
+                            sizes="(max-width: 1024px) 100vw, 33vw"
+                            className="object-cover"
+                            unoptimized
                           />
                         ) : (
                           <div className="flex items-center justify-center h-full">


### PR DESCRIPTION
## Summary
- drop unused teacher assignment state and icons while replacing preview <img> elements with next/image
- memoize teacher assignment data fetching and filtering helpers and update effect dependencies

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce921490848327b7212bd8c85927e1