### PR TITLE
refactor: clean student assignment pages

### DIFF
--- a/apps/web/src/pages/student/assignments/[id].tsx
+++ b/apps/web/src/pages/student/assignments/[id].tsx
@@ -1,32 +1,25 @@
 /* AlFawz Qur'an Institute — generated with TRAE */
 /* Author: Auto-scaffold (review required) */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/router';
-import { 
-  ArrowLeft, 
-  Play, 
-  Pause, 
-  Square, 
-  Mic, 
-  MicOff, 
-  Upload, 
-  Download,
-  Volume2,
-  VolumeX,
+import {
+  ArrowLeft,
+  Play,
+  Pause,
+  Upload,
   Clock,
   CheckCircle,
   AlertCircle,
-  BookOpen,
   Send
 } from 'lucide-react';
+import Image from 'next/image';
 import Layout from '../../../components/Layout';
 import HotspotComponent from '../../../components/assignment/HotspotComponent';
 import AudioRecorder from '../../../components/assignment/AudioRecorder';
-import { useAuth } from '../../../hooks/useAuth';
 import { useAssignment } from '../../../hooks/useAssignment';
-import { Assignment, Hotspot, Submission } from '../../../types/assignment';
+import { Hotspot } from '../../../types/assignment';
 
 /**
  * Assignment Detail Page - displays assignment with interactive hotspots and audio recording.
@@ -35,9 +28,8 @@ import { Assignment, Hotspot, Submission } from '../../../types/assignment';
 const AssignmentDetailPage: React.FC = () => {
   const router = useRouter();
   const { id } = router.query;
-  const { user } = useAuth();
   const { assignment, submission, loading, error, submitAssignment, uploadAudio } = useAssignment(Number(id));
-  
+
   const [selectedHotspot, setSelectedHotspot] = useState<Hotspot | null>(null);
   const [isRecording, setIsRecording] = useState(false);
   const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
@@ -45,7 +37,6 @@ const AssignmentDetailPage: React.FC = () => {
   const [currentAudio, setCurrentAudio] = useState<HTMLAudioElement | null>(null);
   const [showSubmitModal, setShowSubmitModal] = useState(false);
   const imageRef = useRef<HTMLImageElement>(null);
-  const audioRef = useRef<HTMLAudioElement>(null);
 
   /**
    * Handle hotspot click interaction.
@@ -247,10 +238,12 @@ const AssignmentDetailPage: React.FC = () => {
                 {/* Assignment Image with Hotspots */}
                 {assignment.image_s3_url && (
                   <div className="relative">
-                    <img
+                    <Image
                       ref={imageRef}
                       src={assignment.image_s3_url}
                       alt={assignment.title}
+                      width={1200}
+                      height={800}
                       className="w-full h-auto"
                     />
                     

--- a/apps/web/src/pages/student/assignments/index.tsx
+++ b/apps/web/src/pages/student/assignments/index.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Clock, BookOpen, CheckCircle, AlertCircle, Play, Pause } from 'lucide-react';
 import { useRouter } from 'next/router';
+import Image from 'next/image';
 import Layout from '../../../components/Layout';
 import { useAuth } from '../../../hooks/useAuth';
 import { useAssignments } from '../../../hooks/useAssignments';
@@ -23,7 +24,7 @@ const StudentAssignmentDashboard: React.FC = () => {
 
   useEffect(() => {
     if (user) {
-      fetchAssignments();
+      void fetchAssignments();
     }
   }, [user, fetchAssignments]);
 
@@ -182,10 +183,12 @@ const StudentAssignmentDashboard: React.FC = () => {
                   {/* Assignment Image */}
                   {assignment.image_s3_url && (
                     <div className="relative h-48 rounded-t-lg overflow-hidden">
-                      <img
+                      <Image
                         src={assignment.image_s3_url}
                         alt={assignment.title}
-                        className="w-full h-full object-cover"
+                        fill
+                        className="object-cover"
+                        sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
                       />
                       <div className="absolute top-4 right-4">
                         <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${status.color}`}>


### PR DESCRIPTION
## Summary
- replace raw img tags with next/image for the student assignment grid and detail views
- prune unused hooks and icons on student assignment pages to silence lint warnings
- ensure assignment fetching in the student dashboard effect safely awaits the memoised hook

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce9215f3c483278d5eb0006f10d174